### PR TITLE
Fix Playwright install warning by ensuring dependencies are installed first

### DIFF
--- a/lib/demo_scripts/demo_creator.rb
+++ b/lib/demo_scripts/demo_creator.rb
@@ -88,9 +88,9 @@ module DemoScripts
       # - For GitHub sources: install after building packages (dependencies ready after rebuild)
       return if @skip_playwright
 
-      install_playwright_browsers unless using_github_sources?
       build_github_npm_packages if using_github_sources?
-      install_playwright_browsers if using_github_sources?
+      install_playwright_dependencies
+      install_playwright_browsers
     end
 
     def validate_demo_name!(name)
@@ -388,6 +388,12 @@ module DemoScripts
       puts ''
       puts '📦 Installing demo common tools (Playwright, linting, git hooks)...'
       @runner.run!('bin/rails generate shakacode_demo_common:install --force', dir: @demo_dir)
+    end
+
+    def install_playwright_dependencies
+      puts ''
+      puts '📦 Installing Playwright npm dependencies...'
+      @runner.run!('npm install @playwright/test', dir: @demo_dir)
     end
 
     def install_playwright_browsers


### PR DESCRIPTION
## Summary

Fixes the warning message that appears during demo creation:

```
WARNING: It looks like you are running 'npx playwright install' without first
installing your project's dependencies.
```

The issue was that `npx playwright install` was being called before `npm install`, so the `@playwright/test` package wasn't yet installed when we tried to install the browsers.

## Changes

- Added new `install_playwright_dependencies` method that runs `npm install`
- Updated `handle_playwright_installation` to call `install_playwright_dependencies` before `install_playwright_browsers`
- Ensures proper installation order: generator → npm install → playwright install
- Applies to both regular and GitHub source installations

## Test Plan

- [x] All existing RSpec tests pass
- [x] RuboCop passes with no offenses
- [x] Dry-run output shows correct installation order
- [ ] Manual test: Create a new demo and verify no warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)