### PR TITLE
Add HTTP timeouts, port polling, and cleanup incomplete implementations (#15)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 # RuboCop configuration for React on Rails Demos monorepo
 
-require:
+plugins:
   - rubocop-performance
 
 AllCops:

--- a/lib/demo_scripts/demo_creator.rb
+++ b/lib/demo_scripts/demo_creator.rb
@@ -543,12 +543,6 @@ module DemoScripts
       cmd_parts.join(' ')
     end
 
-    def run_automated_tests
-      # Automated testing is complex - requires background process management
-      # For now, we'll skip this and let users run tests manually
-      # Future: implement proper background server and test execution
-    end
-
     def print_completion_message
       puts ''
       puts '=' * 80

--- a/packages/shakacode_demo_common/spec/lib/shakacode_demo_common/e2e_test_runner_spec.rb
+++ b/packages/shakacode_demo_common/spec/lib/shakacode_demo_common/e2e_test_runner_spec.rb
@@ -249,9 +249,11 @@ RSpec.describe ShakacodeDemoCommon::ServerManager do
   describe '#server_responding?' do
     let(:uri) { URI('http://localhost:3000') }
     let(:response) { instance_double(Net::HTTPResponse, code: '200') }
+    let(:http) { instance_double(Net::HTTP) }
 
     before do
-      allow(Net::HTTP).to receive(:get_response).with(uri).and_return(response)
+      allow(Net::HTTP).to receive(:start).and_yield(http)
+      allow(http).to receive(:get).and_return(response)
     end
 
     it 'returns true for successful response' do
@@ -275,12 +277,12 @@ RSpec.describe ShakacodeDemoCommon::ServerManager do
     end
 
     it 'returns false when connection is refused' do
-      allow(Net::HTTP).to receive(:get_response).and_raise(Errno::ECONNREFUSED)
+      allow(Net::HTTP).to receive(:start).and_raise(Errno::ECONNREFUSED)
       expect(server.send(:server_responding?)).to be false
     end
 
     it 'returns false for socket errors' do
-      allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+      allow(Net::HTTP).to receive(:start).and_raise(SocketError)
       expect(server.send(:server_responding?)).to be false
     end
   end


### PR DESCRIPTION
## Summary

This PR addresses all items from issue #15, adding robustness and reliability improvements to the E2E test infrastructure:

- **Removed incomplete `run_automated_tests` method** - Was never called and only contained TODO comments
- **Replaced fixed sleep with intelligent port polling** - Polls port availability instead of fixed 2-second delay, handling slow systems better
- **Added HTTP timeouts** - Prevents indefinite hangs with 2-second timeouts on server health checks
- **Fixed RuboCop configuration** - Changed from deprecated `require:` to modern `plugins:` syntax
- **Updated tests** - Modified mocks to work with new HTTP timeout implementation

## Key Improvements

### Port Polling (`e2e_test_runner.rb:53-69`)
- Polls port availability up to 10 times with 0.5s intervals
- Returns early when port is released (faster on systems with quick cleanup)
- Logs warning if port remains in use after polling
- More robust on slow systems or when server cleanup takes longer

### HTTP Timeouts (`e2e_test_runner.rb:159-170`)
- Added `open_timeout: 2` and `read_timeout: 2` to HTTP requests
- Catches `Net::OpenTimeout` and `Net::ReadTimeout` exceptions
- Prevents test suite from hanging indefinitely on stuck servers

### Code Cleanup
- Removed unused `run_automated_tests` method from `demo_creator.rb`
- Simplified codebase by removing TODO-only methods

### RuboCop Configuration (`.rubocop.yml:3`)
- Changed from `require:` to `plugins:` syntax
- Eliminates warning about rubocop-performance extension
- Follows current best practices for RuboCop >= 1.0

## Test Plan

- [x] All E2E test runner specs pass (31 examples, 0 failures)
- [x] RuboCop passes with no offenses
- [x] Updated test mocks to work with new HTTP.start implementation
- [x] Pre-commit hooks pass

## Breaking Changes

None - these are internal improvements to test infrastructure

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)