### PR TITLE
Fix yarn/npm mixing by specifying npm for cypress-on-rails

### DIFF
--- a/packages/shakacode_demo_common/lib/generators/shakacode_demo_common/install/install_generator.rb
+++ b/packages/shakacode_demo_common/lib/generators/shakacode_demo_common/install/install_generator.rb
@@ -116,11 +116,12 @@ module ShakacodeDemoCommon
 
       def install_cypress_on_rails_with_playwright
         say 'Installing cypress-on-rails with Playwright framework'
-        success = run 'bin/rails generate cypress_on_rails:install --framework playwright --install_folder e2e'
+        command = 'bin/rails generate cypress_on_rails:install --framework playwright ' \
+                  '--install_folder e2e --install_with npm'
+        success = run command
 
         unless success
           say 'Failed to install cypress-on-rails generator', :red
-          command = 'bin/rails generate cypress_on_rails:install --framework playwright --install_folder e2e'
           say "You may need to run: #{command}", :yellow
         end
 


### PR DESCRIPTION
## Summary
- Added `--install_with npm` flag to cypress-on-rails generator call to ensure npm is used consistently

## Problem
The cypress-on-rails generator defaults to using yarn, but our demos use npm and specify `"packageManager": "npm@11.6.0"` in package.json. This caused errors when the generator tried to install Playwright packages with yarn:

```
error This project's package.json defines "packageManager": "yarn@npm@11.6.0". 
However the current global version of Yarn is 1.22.22.
```

## Solution
Pass `--install_with npm` to the `cypress_on_rails:install` generator to ensure it uses npm instead of the default yarn.

## Testing
- The fix should be tested by running `bin/new-demo --typescript --scratch ts-basic` and verifying that Playwright installs successfully without yarn/npm conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Generator installation now supports npm via an added install flag, enabling dependency setup with npm.
- Bug Fixes
  - More reliable reporting of installation outcomes with consistent success/failure handling.
- Refactor
  - Streamlined command execution and messaging for the install step to reduce duplication and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->