### PR TITLE
Fix Bundler syntax for Git tags in swap-deps (#38)

### DIFF
--- a/lib/demo_scripts/gem_swapper.rb
+++ b/lib/demo_scripts/gem_swapper.rb
@@ -278,9 +278,13 @@ module DemoScripts
         # Extract options after version (if any)
         options = rest.sub(/^\s*,\s*(['"])[^'"]*\1/, '') # Remove version if present
 
-        # Build replacement: gem 'name', github: 'user/repo', branch: 'branch-name' [, options...]
+        # Build replacement: gem 'name', github: 'user/repo', branch/tag: 'ref' [, options...]
         replacement = "#{indent}gem #{quote}#{gem_name}#{quote}, github: #{quote}#{info[:repo]}#{quote}"
-        replacement += ", branch: #{quote}#{info[:branch]}#{quote}" if info[:branch] != 'main'
+        if info[:branch] != 'main'
+          # Use 'tag:' for tags, 'branch:' for branches
+          param_name = info[:ref_type] == :tag ? 'tag' : 'branch'
+          replacement += ", #{param_name}: #{quote}#{info[:branch]}#{quote}"
+        end
         replacement += options unless options.strip.empty?
         replacement
       end

--- a/spec/demo_scripts/gem_swapper_spec.rb
+++ b/spec/demo_scripts/gem_swapper_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe DemoScripts::DependencySwapper do
   end
 
   describe '#swap_gem_to_github' do
-    let(:github_info) { { repo: 'shakacode/shakapacker', branch: 'main' } }
+    let(:github_info) { { repo: 'shakacode/shakapacker', branch: 'main', ref_type: :branch } }
 
     context 'with main branch' do
       let(:gemfile_content) { "gem 'shakapacker', '~> 9.0.0'\n" }
@@ -148,7 +148,7 @@ RSpec.describe DemoScripts::DependencySwapper do
 
     context 'with custom branch' do
       let(:gemfile_content) { "gem 'shakapacker', '~> 9.0.0'\n" }
-      let(:github_info) { { repo: 'shakacode/shakapacker', branch: 'fix-hmr' } }
+      let(:github_info) { { repo: 'shakacode/shakapacker', branch: 'fix-hmr', ref_type: :branch } }
 
       it 'includes branch parameter' do
         result = swapper.send(:swap_gem_to_github, gemfile_content, 'shakapacker', github_info)
@@ -156,9 +156,19 @@ RSpec.describe DemoScripts::DependencySwapper do
       end
     end
 
+    context 'with tag' do
+      let(:gemfile_content) { "gem 'shakapacker', '~> 9.0.0'\n" }
+      let(:github_info) { { repo: 'shakacode/shakapacker', branch: 'v1.0.0', ref_type: :tag } }
+
+      it 'uses tag parameter instead of branch' do
+        result = swapper.send(:swap_gem_to_github, gemfile_content, 'shakapacker', github_info)
+        expect(result).to eq("gem 'shakapacker', github: 'shakacode/shakapacker', tag: 'v1.0.0'\n")
+      end
+    end
+
     context 'with additional options' do
       let(:gemfile_content) { "gem 'shakapacker', '~> 9.0.0', require: false\n" }
-      let(:github_info) { { repo: 'shakacode/shakapacker', branch: 'develop' } }
+      let(:github_info) { { repo: 'shakacode/shakapacker', branch: 'develop', ref_type: :branch } }
 
       it 'preserves options' do
         result = swapper.send(:swap_gem_to_github, gemfile_content, 'shakapacker', github_info)


### PR DESCRIPTION
## Summary
- Fixes incorrect Bundler syntax when using `@tag` format with swap-deps
- Tool now correctly uses `tag:` parameter for Git tags instead of `branch:`
- Added test coverage for tag functionality

## Problem
When using `bin/swap-deps --github user/repo@v1.0.0`, the tool was generating:
```ruby
gem "foo", github: "user/repo", branch: "v1.0.0"
```

This is incorrect - Bundler requires the `tag:` parameter for tags, not `branch:`.

## Solution
The parsing logic already correctly detected tags vs branches and set `ref_type`. The fix was to use this information in the `swap_gem_to_github` method to generate the correct parameter name.

Now generates:
```ruby
gem "foo", github: "user/repo", tag: "v1.0.0"
```

## Test Plan
- [x] Added new RSpec test for tag functionality
- [x] All existing tests pass
- [x] RuboCop passes
- [x] Pre-commit hooks pass

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)