### PR TITLE
Clarify GitHub spec parser documentation

### DIFF
--- a/lib/demo_scripts/github_spec_parser.rb
+++ b/lib/demo_scripts/github_spec_parser.rb
@@ -12,7 +12,8 @@ module DemoScripts
     #   org/repo           -> [org/repo, nil, nil]
     #   org/repo#branch    -> [org/repo, branch, :branch]
     #   org/repo@tag       -> [org/repo, tag, :tag]
-    #   org/repo@branch    -> [org/repo, branch, :branch] (backward compatibility)
+    #
+    # Note: @ always indicates a tag (use # for branches)
     def parse_github_spec(github_spec)
       if github_spec.include?('@')
         parts = github_spec.split('@', 2)


### PR DESCRIPTION
## Summary
Small documentation cleanup - removes confusing backward compatibility comment.

## Changes
- Removed `org/repo@branch -> [org/repo, branch, :branch] (backward compatibility)` comment
- Added clear note: "@ always indicates a tag (use # for branches)"

This makes the documentation consistent with the actual behavior after PR #43 was merged.

## Why
The old comment suggested `@` could be used for branches (for backward compatibility), which is confusing now that we have a clear distinction:
- `#` for branches
- `@` for tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)