### PR TITLE
Improve swap-deps error handling for deleted directories

### DIFF
--- a/lib/demo_scripts/gem_swapper.rb
+++ b/lib/demo_scripts/gem_swapper.rb
@@ -519,7 +519,15 @@ module DemoScripts
       gem_paths.each do |gem_name, path|
         next if File.directory?(path)
 
-        raise Error, "Local path for #{gem_name} does not exist: #{path}"
+        error_msg = "Local path for #{gem_name} does not exist: #{path}\n\n"
+        error_msg += "This usually means:\n"
+        error_msg += "  1. The path in .swap-deps.yml is outdated\n"
+        error_msg += "  2. You moved or deleted the local repository\n\n"
+        error_msg += "To fix:\n"
+        error_msg += "  - Update .swap-deps.yml with the correct path\n"
+        error_msg += '  - Or use --restore to restore original dependencies'
+
+        raise Error, error_msg
       end
     end
 


### PR DESCRIPTION
## Summary
- Enhanced error message when swap-deps encounters missing directory paths
- Provides helpful guidance on how to fix the issue (update config or use --restore)

## Changes
- Updated `validate_local_paths!` to provide a more informative error message that includes:
  - The path that doesn't exist
  - Common causes (outdated config, deleted repo)
  - Suggested fixes

## Test plan
- [x] All existing tests pass
- [x] RuboCop passes  
- [x] Minimal change - only the error message is improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved error message when a local dependency path is missing. Users now see a clear, multi-line explanation with likely causes (e.g., outdated path, moved/deleted repo) and actionable steps to resolve (update configuration or restore).
  - Provides guidance to quickly correct .swap-deps.yml entries or use the restore option, reducing confusion and speeding up troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->