### PR TITLE
Fix lock file updates when restoring dependencies

### DIFF
--- a/lib/demo_scripts/gem_swapper.rb
+++ b/lib/demo_scripts/gem_swapper.rb
@@ -842,6 +842,7 @@ module DemoScripts
             system('bundle', 'install', '--quiet')
           end
         else
+          puts "  Updating gems: #{gems_to_update.join(', ')}" if verbose
           success = Dir.chdir(demo_path) do
             # Update specific gems to pull from rubygems
             result = system('bundle', 'update', *gems_to_update, '--quiet')
@@ -856,7 +857,7 @@ module DemoScripts
         end
       end
 
-      warn '  ⚠️  Warning: bundle command failed' unless success
+      warn '  ⚠️  ERROR: bundle command failed' unless success
       success
     end
     # rubocop:enable Metrics/MethodLength
@@ -874,9 +875,12 @@ module DemoScripts
         package_lock_backup = "#{package_lock_path}.backup"
 
         # Atomically move package-lock.json to backup to avoid race conditions
-        if File.exist?(package_lock_path)
+        begin
           File.rename(package_lock_path, package_lock_backup)
           puts '  Moved package-lock.json to backup for regeneration' if verbose
+        rescue Errno::ENOENT
+          # File doesn't exist, which is fine - nothing to backup
+          puts '  No package-lock.json found to backup' if verbose
         end
 
         success = Dir.chdir(demo_path) do
@@ -900,7 +904,7 @@ module DemoScripts
         end
       end
 
-      warn '  ⚠️  Warning: npm install failed' unless success
+      warn '  ⚠️  ERROR: npm install failed' unless success
       success
     end
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
## Summary
- Fixes lock files (Gemfile.lock, package-lock.json) not updating properly after restore
- Ensures dependencies are fully restored from registry sources

## Problem
When running `bin/swap-deps --restore`, the Gemfile and package.json files were restored correctly, but the lock files retained references to the local paths. This meant `git status` showed modified lock files even after restore.

## Solution
### For Bundler
- Use `bundle update <gem>` for swapped gems during restore to force re-resolution from rubygems
- This ensures Gemfile.lock properly reflects the restored version constraints

### For npm  
- Remove package-lock.json before running npm install during restore
- This forces npm to re-resolve dependencies from the registry

## Test plan
- [x] All existing tests pass
- [x] RuboCop passes
- [ ] Manual testing: swap -> restore -> verify lock files are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restore mode for dependency installation that selectively updates supported Ruby gems and regenerates JavaScript lockfiles to align restored dependencies.

* **Bug Fixes**
  * Targeted gem updates with fallback to full install; failures now surface clear warnings to reduce restore breakage.

* **UX**
  * Improved terminal messaging indicating targeted updates, lockfile regeneration, and restoration warnings.

* **Tests**
  * Added tests covering restore and regular install flows, lockfile backup/restore, success/failure, and missing-file scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->