### PR TITLE
Improve swap-deps restore guidance for users

### DIFF
--- a/lib/demo_scripts/gem_swapper.rb
+++ b/lib/demo_scripts/gem_swapper.rb
@@ -70,7 +70,7 @@ module DemoScripts
       end
 
       if restored_count.zero?
-        puts 'ℹ️  No backup files found - nothing to restore'
+        print_no_backups_message
       else
         puts "✅ Restored #{restored_count} file(s) from backups"
       end
@@ -220,6 +220,23 @@ module DemoScripts
     }
 
     private
+
+    def print_no_backups_message
+      puts 'ℹ️  No backup files found - nothing to restore'
+      puts ''
+      puts '   This means either:'
+      puts '   - Dependencies have not been swapped yet'
+      puts '   - Dependencies were already restored'
+      puts '   - Backup files were manually deleted'
+      puts ''
+      puts '   💡 Next steps:'
+      puts '   - Check current status: bin/swap-deps --status'
+      puts '   - Swap dependencies: bin/swap-deps --apply (or specify paths/repos)'
+      puts '   - Manual restore: If backup files exist but restore failed, you can:'
+      puts '     - Copy Gemfile.backup to Gemfile'
+      puts '     - Copy package.json.backup to package.json'
+      puts '     - Run: bundle install && npm install'
+    end
 
     def show_demo_status(demo_path)
       puts "\n📦 #{demo_name(demo_path)}:"

--- a/lib/demo_scripts/swap_deps_cli.rb
+++ b/lib/demo_scripts/swap_deps_cli.rb
@@ -146,7 +146,8 @@ module DemoScripts
           @apply_config = true
         end
 
-        opts.on('--restore', 'Restore original dependency versions from backups') do
+        opts.on('--restore', 'Restore original dependency versions from backups',
+                '(Copies .backup files back and reinstalls dependencies)') do
           @restore = true
         end
 
@@ -253,6 +254,11 @@ module DemoScripts
           puts ''
           puts '  # Restore original versions'
           puts '  bin/swap-deps --restore'
+          puts ''
+          puts '  # Manual restore (if automated restore fails)'
+          puts '  # Copy Gemfile.backup to Gemfile'
+          puts '  # Copy package.json.backup to package.json'
+          puts '  # Run: bundle install && npm install'
           puts ''
           puts '  # Preview without making changes'
           puts '  bin/swap-deps --dry-run --react-on-rails ~/dev/react_on_rails'


### PR DESCRIPTION
## Summary

Enhance the user experience when running `bin/swap-deps --restore` with no backup files present.

**Changes:**
- Add detailed explanation when no backups are found (not swapped yet, already restored, or manually deleted)
- Provide clear next steps including checking status with `--status` flag
- Include manual restore instructions for edge cases where automated restore might fail
- Add manual restore example to `--help` output
- Improve `--restore` flag description in help text

## Test plan

- [x] Tested `bin/swap-deps --restore` with no backups - shows helpful message
- [x] Tested `bin/swap-deps --help` - includes new manual restore section
- [x] Verified RuboCop passes
- [x] Verified all files end with newlines

## Why this helps

This addresses confusion when users try to restore but there are no backups, especially in workspace scenarios where the state might not be clear. The enhanced messaging guides users through understanding their current state and provides actionable next steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI help for the restore option with an additional line describing manual restoration steps (copy backup files and reinstall dependencies).
  * Improved the message shown when no backups are found during restore, replacing a single-line notice with a clearer, multi-line guidance block outlining next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->