### PR TITLE
Fix bundle update after swap-deps

### DIFF
--- a/spec/demo_scripts/gem_swapper_spec.rb
+++ b/spec/demo_scripts/gem_swapper_spec.rb
@@ -772,7 +772,25 @@ RSpec.describe DemoScripts::DependencySwapper do
     end
 
     context 'when for_restore is false' do
-      it 'runs regular bundle install' do
+      it 'runs bundle update for swapped gems' do
+        gemfile_content = <<~GEMFILE
+          gem 'rails'
+          gem 'shakapacker', path: '/path/to/shakapacker'
+          gem 'react_on_rails', github: 'shakacode/react_on_rails'
+        GEMFILE
+
+        allow(File).to receive(:read).with(gemfile_path).and_return(gemfile_content)
+        expect(Dir).to receive(:chdir).with(demo_path).and_yield
+        expect(swapper).to receive(:system).with('bundle', 'update', 'shakapacker', 'react_on_rails',
+                                                 '--quiet').and_return(true)
+
+        swapper.send(:run_bundle_install, demo_path, for_restore: false)
+      end
+
+      it 'runs regular bundle install when no supported gems found' do
+        gemfile_content = "gem 'rails'\ngem 'pg'"
+
+        allow(File).to receive(:read).with(gemfile_path).and_return(gemfile_content)
         expect(Dir).to receive(:chdir).with(demo_path).and_yield
         expect(swapper).to receive(:system).with('bundle', 'install', '--quiet').and_return(true)
 


### PR DESCRIPTION
## Summary

- When swapping to local/GitHub dependencies, automatically run `bundle update` for the swapped gems instead of just `bundle install`
- This resolves lock file conflicts that occur when the Gemfile.lock references a version that's no longer available in the new source

## Problem

When running `swap-deps --github 'shakacode/shakapacker#justin808/early-hints'`, users would encounter an error:

```
Your bundle is locked to shakapacker (9.0.0) from https://github.com/shakacode/shakapacker.git (at justin808/early-hints@6420a16), but that version can no longer be found in that source. You'll need to update your bundle to a version other than shakapacker (9.0.0) that hasn't been removed in order to install.
```

This required users to manually run `bundle update shakapacker` after the swap completed.

## Solution

The `run_bundle_install` method now automatically detects swapped gems in the Gemfile and runs `bundle update <gem1> <gem2>` instead of `bundle install` when swapping dependencies. This ensures the Gemfile.lock is properly updated to reference the new source.

## Test plan

- [x] Updated existing test to verify `bundle update` is called for swapped gems
- [x] Added test to verify `bundle install` is still used when no supported gems are found
- [x] All RuboCop checks pass
- [x] All relevant tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gem dependency resolution when sources are swapped by performing targeted updates instead of full installs, reducing lockfile conflicts.

* **Improvements**
  * Optimized dependency processing logic through precomputed gem lists for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->