### PR TITLE
Auto-install npm dependencies before building packages

### DIFF
--- a/lib/demo_scripts/gem_swapper.rb
+++ b/lib/demo_scripts/gem_swapper.rb
@@ -1126,6 +1126,17 @@ module DemoScripts
         return
       end
 
+      # Install dependencies first if node_modules doesn't exist
+      node_modules = File.join(npm_path, 'node_modules')
+      unless File.directory?(node_modules)
+        puts "  Installing dependencies for #{gem_name}..."
+        success = Dir.chdir(npm_path) do
+          system('npm', 'install', out: '/dev/null', err: '/dev/null')
+        end
+        warn "  ⚠️  Warning: npm install failed for #{gem_name}" unless success
+        return unless success
+      end
+
       data = JSON.parse(File.read(package_json))
       build_script = data.dig('scripts', 'build')
 


### PR DESCRIPTION
## Summary
- Automatically runs `npm install` before `npm run build` for GitHub-cloned repos if `node_modules` doesn't exist
- Fixes "tsc: command not found" error when building packages from freshly cloned repos

## Test plan
- [x] Tested with `bin/swap-deps --github 'shakacode/shakapacker#justin808/early-hints'`
- [x] Verified npm install runs automatically before build
- [x] Verified package builds successfully
- [x] Verified dev server starts without errors
- [x] Rubocop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Builds now automatically install missing dependencies when needed, improving reliability and reducing manual setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->