### PR TITLE
Remove stray call to undefined run_automated_tests method

### DIFF
--- a/lib/demo_scripts/demo_creator.rb
+++ b/lib/demo_scripts/demo_creator.rb
@@ -65,7 +65,6 @@ module DemoScripts
       create_readme
       cleanup_unnecessary_files
       create_metadata_file
-      run_automated_tests unless @dry_run
 
       print_completion_message
     end


### PR DESCRIPTION
## Summary
- Fixes NameError when creating new demos by removing call to undefined `run_automated_tests` method

## Details
The `run_automated_tests` method was removed in commit f5b1e3b (12 days ago) but a call to it on line 68 was accidentally left in the `create!` method. This caused a NameError whenever a new demo was created.

## Testing
- ✅ All specs pass (`bundle exec rspec spec/demo_scripts/demo_creator_spec.rb`)
- ✅ RuboCop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted automated testing behavior during creation operations to skip tests in standard workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->