### PR TITLE
Add an experimental demo fleet control plane

### DIFF
--- a/.github/workflows/demo-fleet-ci.yml
+++ b/.github/workflows/demo-fleet-ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-fleet-ci.yml
+++ b/.github/workflows/demo-fleet-ci.yml
@@ -1,0 +1,27 @@
+name: Demo Fleet CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run lint
+        run: bundle exec rubocop lib/demo_fleet.rb lib/demo_fleet script test/demo_fleet_test.rb Rakefile
+
+      - name: Run tests
+        run: ruby -Ilib test/demo_fleet_test.rb
+
+      - name: Validate manifest
+        run: script/demo-fleet validate --manifest test/fixtures/demo-fleet.yml

--- a/.github/workflows/demo-fleet-freshness.yml
+++ b/.github/workflows/demo-fleet-freshness.yml
@@ -1,0 +1,25 @@
+name: Demo Fleet Freshness Plan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 10 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Validate manifest
+        run: script/demo-fleet validate
+
+      - name: Render freshness update plan
+        run: script/demo-fleet update-plan --track freshness >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/demo-fleet-release-plan.yml
+++ b/.github/workflows/demo-fleet-release-plan.yml
@@ -1,0 +1,108 @@
+name: Demo Fleet Release Plan
+
+on:
+  workflow_dispatch:
+    inputs:
+      react_on_rails:
+        description: React on Rails gem version
+        required: true
+      react_on_rails_pro:
+        description: React on Rails Pro gem version
+        required: true
+      react_on_rails_npm:
+        description: react-on-rails npm version
+        required: true
+      react_on_rails_pro_npm:
+        description: react-on-rails-pro npm version
+        required: true
+      react_on_rails_pro_node_renderer_npm:
+        description: react-on-rails-pro-node-renderer npm version
+        required: true
+      react_on_rails_rsc_npm:
+        description: react-on-rails-rsc npm version
+        required: true
+      shakapacker:
+        description: Optional ShakaPacker gem version
+        required: false
+      shakapacker_npm:
+        description: Optional ShakaPacker npm version
+        required: false
+      shakapacker_rspack_npm:
+        description: Optional shakapacker-rspack npm version
+        required: false
+      cpflow:
+        description: Optional CPFlow gem version
+        required: false
+      tier:
+        description: Optional tier filter, such as hard_gate
+        required: false
+      repo:
+        description: Optional repo id filter, such as react-on-rails-demo-marketplace-rsc
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Validate manifest
+        run: script/demo-fleet validate
+
+      - name: Dry-run release update plan
+        env:
+          REACT_ON_RAILS_GEM: ${{ inputs.react_on_rails }}
+          REACT_ON_RAILS_PRO_GEM: ${{ inputs.react_on_rails_pro }}
+          REACT_ON_RAILS_NPM: ${{ inputs.react_on_rails_npm }}
+          REACT_ON_RAILS_PRO_NPM: ${{ inputs.react_on_rails_pro_npm }}
+          REACT_ON_RAILS_PRO_NODE_RENDERER_NPM: ${{ inputs.react_on_rails_pro_node_renderer_npm }}
+          REACT_ON_RAILS_RSC_NPM: ${{ inputs.react_on_rails_rsc_npm }}
+          SHAKAPACKER_GEM: ${{ inputs.shakapacker }}
+          SHAKAPACKER_NPM: ${{ inputs.shakapacker_npm }}
+          SHAKAPACKER_RSPACK_NPM: ${{ inputs.shakapacker_rspack_npm }}
+          CPFLOW_GEM: ${{ inputs.cpflow }}
+          TIER: ${{ inputs.tier }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          args=(
+            --track release
+            --gem "react_on_rails=$REACT_ON_RAILS_GEM"
+            --gem "react_on_rails_pro=$REACT_ON_RAILS_PRO_GEM"
+            --npm "react-on-rails=$REACT_ON_RAILS_NPM"
+            --npm "react-on-rails-pro=$REACT_ON_RAILS_PRO_NPM"
+            --npm "react-on-rails-pro-node-renderer=$REACT_ON_RAILS_PRO_NODE_RENDERER_NPM"
+            --npm "react-on-rails-rsc=$REACT_ON_RAILS_RSC_NPM"
+          )
+
+          if [[ -n "$SHAKAPACKER_GEM" ]]; then
+            args+=(--gem "shakapacker=$SHAKAPACKER_GEM")
+          fi
+
+          if [[ -n "$SHAKAPACKER_NPM" ]]; then
+            args+=(--npm "shakapacker=$SHAKAPACKER_NPM")
+          fi
+
+          if [[ -n "$SHAKAPACKER_RSPACK_NPM" ]]; then
+            args+=(--npm "shakapacker-rspack=$SHAKAPACKER_RSPACK_NPM")
+          fi
+
+          if [[ -n "$CPFLOW_GEM" ]]; then
+            args+=(--gem "cpflow=$CPFLOW_GEM")
+          fi
+
+          if [[ -n "$TIER" ]]; then
+            args+=(--tier "$TIER")
+          fi
+
+          if [[ -n "$REPO" ]]; then
+            args+=(--repo "$REPO")
+          fi
+
+          script/demo-fleet execute-plan --dry-run "${args[@]}" >> "$GITHUB_STEP_SUMMARY"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,9 +9,9 @@ AllCops:
   TargetRubyVersion: 3.1
   Exclude:
     - 'node_modules/**/*'
-    - 'demos/**/*'  # Each demo has its own Gemfile and rubocop config
+    - 'demos/**/*' # Each demo has its own Gemfile and rubocop config
     - 'packages/shakacode_demo_common/node_modules/**/*'
-    - 'bin/conductor-exec'  # Shell script, not Ruby
+    - 'bin/conductor-exec' # Shell script, not Ruby
 
 # Allow longer blocks in specs, Rakefiles, and bin scripts
 Metrics/BlockLength:
@@ -22,29 +22,49 @@ Metrics/BlockLength:
     - '**/Rakefile'
     - 'packages/shakacode_demo_common/lib/tasks/**/*.rake'
     - 'bin/*'
+    - 'test/**/*_test.rb'
 
 # Allow longer methods in demo creation (complex setup)
 Metrics/MethodLength:
   Max: 20
+  AllowedMethods:
+    - split_ruby_arguments
   Exclude:
     - 'lib/demo_scripts/demo_creator.rb'
     - 'lib/demo_scripts/demo_scaffolder.rb'
+    - 'lib/demo_fleet/cli.rb'
+    - 'lib/demo_fleet/update_planner.rb'
+    - 'test/**/*_test.rb'
 
 # Allow longer classes for demo creators and bin scripts (lots of setup code)
 Metrics/ClassLength:
   Max: 300
   Exclude:
     - 'bin/*'
+    - 'test/**/*_test.rb'
 
 # Allow more complex methods for demo scaffolding
 Metrics/AbcSize:
   Max: 25
+  AllowedMethods:
+    - split_ruby_arguments
+  Exclude:
+    - 'lib/demo_fleet/cli.rb'
+    - 'lib/demo_fleet/executor.rb'
+    - 'lib/demo_fleet/update_planner.rb'
+    - 'test/**/*_test.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 10
+  AllowedMethods:
+    - split_ruby_arguments
+  Exclude:
+    - 'test/**/*_test.rb'
 
 Metrics/PerceivedComplexity:
   Max: 12
+  AllowedMethods:
+    - split_ruby_arguments
 
 # Allow more parameters for demo scaffolder (lots of options)
 Metrics/ParameterLists:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,48 @@ npm run format:check
 
 See [Development Setup](./docs/CONTRIBUTING_SETUP.md) for details.
 
+## Cross-Repository Demo Fleet
+
+This repository also hosts the experimental runtime for planning dependency updates across the
+ShakaCode demo fleet. Release policy, the fleet inventory, RC prompts, and the final go/no-go
+decision remain authoritative in
+[`shakacode/react_on_rails`](https://github.com/shakacode/react_on_rails/tree/main/internal/contributor-info).
+The runtime reads that canonical manifest directly instead of maintaining a second fleet list.
+
+```bash
+# Validate the current canonical manifest.
+script/demo-fleet validate
+
+# Render a non-mutating plan for one published release.
+script/demo-fleet execute-plan \
+  --track release \
+  --dry-run \
+  --gem react_on_rails=17.0.0.rc.10 \
+  --gem react_on_rails_pro=17.0.0.rc.10 \
+  --npm react-on-rails=17.0.0-rc.10 \
+  --npm react-on-rails-pro=17.0.0-rc.10 \
+  --npm react-on-rails-pro-node-renderer=17.0.0-rc.10 \
+  --npm react-on-rails-rsc=19.2.1-rc.1
+```
+
+Entries marked `verify: true` in the canonical manifest are deliberately excluded from plans. At
+the time this pilot was added, all canonical entries were still pending that one-time verification,
+so execution refuses to run until the release-policy owner confirms the metadata, including the
+review-app name, and clears those flags. This makes stale or placeholder metadata visible without
+turning it into repository mutations.
+
+The release updater handles direct npm declarations in nested applications, runs installs beside
+each changed manifest, and permits missing targets only when a repo explicitly marks them as
+transitive-only. It rejects tracked, staged, or untracked output outside dependency manifests,
+lockfiles, Yarn Berry dependency artifacts, and the verification script.
+
+Use `--manifest PATH_OR_URL` or `DEMO_FLEET_MANIFEST` to test an unmerged manifest change. Remote
+mutation is opt-in: `execute-plan` requires both `--execute --workspace PATH`, and it only pushes
+branches or opens draft PRs when `--allow-remote-prs` is also present.
+
+See the [control-plane notes](./docs/demo-fleet-control-plane-design.md) for the ownership boundary,
+current limitations, and verification commands.
+
 ### Bootstrap All Demos
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
-# React on Rails Demos
+# React on Rails Demo Fleet
 
-A monorepo containing demo applications showcasing various features and best practices for [React on Rails](https://github.com/shakacode/react_on_rails).
+Backstage engineering for the [React on Rails examples](https://reactonrails.com/examples): shared
+tooling, compact reference fixtures, and the control plane that keeps independently deployed demo
+applications current and verifiable.
+
+The examples website is the canonical public catalog, with screenshots, live deployments, source
+links, starters, and production references. Flagship applications remain in their own repositories
+so each retains independent CI, deployment, review-app, history, and ownership boundaries. This
+repository does not duplicate those applications or maintain a second human-facing catalog.
+
+## Responsibilities
+
+| Surface                                                                   | Responsibility                                                         |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [`reactonrails.com/examples`](https://reactonrails.com/examples)          | Public discovery and evaluation                                        |
+| Individual demo repositories                                              | Application source, CI, deployment, and review apps                    |
+| This repository                                                           | Shared tooling, fixture demos, fleet planning, and update verification |
+| [`shakacode/react_on_rails`](https://github.com/shakacode/react_on_rails) | Product source, release policy, and canonical fleet inventory          |
 
 ## Repository Structure
 
 ```
 react_on_rails-demos/
+├─ lib/demo_fleet/                    # Cross-repository planning and execution runtime
+├─ script/demo-fleet                  # Fleet command-line entry point
+├─ templates/demo-repo/               # Shared verification and dependency templates
 ├─ packages/
 │  └─ shakacode_demo_common/          # Shared configuration and utilities
 │     ├─ Gemfile           # Shared Ruby dependencies
@@ -13,18 +32,15 @@ react_on_rails-demos/
 │     ├─ config/            # Shared linting configs
 │     └─ lib/               # Ruby utilities and templates
 └─ demos/
-   ├─ react_on_rails-demo-v16-ssr-auto-registration-bundle-splitting/
-   ├─ react_on_rails-demo-v16-react-server-components/
-   └─ ...                   # Additional demo applications
+   ├─ basic-v16-rspack/                # Compact local reference fixture
+   └─ basic-v16-webpack/               # Compact local reference fixture
 ```
 
 ## Demo Applications
 
-Each demo follows the naming convention: `react_on_rails-demo-v[version]-[topics]`
-
-### Available Demos
-
-_(Demos will be listed here as they are added)_
+The small applications under `demos/` exercise shared repository tooling. For maintained flagship,
+starter, production, and legacy examples, use the
+[public examples catalog](https://reactonrails.com/examples).
 
 ## Getting Started
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,12 @@ require 'rubocop/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
+desc 'Run demo fleet control-plane tests'
+task :demo_fleet_test do
+  ruby '-Ilib', 'test/demo_fleet_test.rb'
+end
+
 task default: %i[spec rubocop]
 
 desc 'Run all tests and linting'
-task test: :default
+task test: %i[default demo_fleet_test]

--- a/docs/demo-fleet-control-plane-design.md
+++ b/docs/demo-fleet-control-plane-design.md
@@ -1,0 +1,68 @@
+# Demo Fleet Control Plane
+
+## Ownership
+
+The control plane has a deliberately split ownership model:
+
+1. [`shakacode/react_on_rails`](https://github.com/shakacode/react_on_rails/tree/main/internal/contributor-info)
+   owns release policy, the canonical `demo-fleet.yml`, RC prompts, tracking issues, and final
+   release decisions.
+2. This repository owns reusable runtime mechanics: parsing the canonical manifest, rendering
+   deterministic plans, applying exact versions, bounded parallel execution, and opt-in PR setup.
+3. Each demo repository owns its tests, build, review-app deployment, smoke behavior, and any
+   repository-specific upgrade work.
+
+The runtime defaults to the manifest on `react_on_rails/main`. A release manager can pass
+`--manifest PATH_OR_URL` (or set `DEMO_FLEET_MANIFEST`) to exercise an unmerged policy change. This
+keeps one inventory and prevents an operational snapshot here from silently drifting.
+
+The canonical manifest's `verify: true` marker means an entry is still a draft. Such entries are
+reported by `validate` but excluded from actionable plans. `execute-plan --dry-run` reports an empty
+selection successfully for hosted planning, while mutating execution refuses an empty selection,
+and an entry cannot become actionable until `review_app.cpflow_app_name` is present unless it
+explicitly sets `review_app: null` to opt out. The exact-version updater fails if a requested gem is
+absent from the checkout's root `Gemfile`. For npm, it searches
+bounded repository manifests (excluding dependency, cache, and generated directories), updates every
+direct declaration, and only permits a missing declaration when that package is named in the repo's
+`transitive_only_npm_packages`. Installs run in each directory whose `package.json` changed, which
+covers split layouts such as HiChee's root and `client` applications.
+
+Pro-only apps are a bounded exception: directly declaring the Pro gem or npm package satisfies the
+corresponding base React on Rails target because Pro depends on it. Other absent targets still fail
+closed unless the canonical manifest marks them as transitive-only.
+
+## Safety Boundary
+
+`update-plan` and `execute-plan --dry-run` do not mutate demo repositories. The pilot executor
+requires an explicit workspace for mutations. It commits local changes but does not push or open a
+draft PR unless `--allow-remote-prs` is supplied.
+
+Mutating runs require an authenticated GitHub CLI. Fresh checkouts use its configured Git protocol
+so the same path works for public and private fleet repositories and later pushes retain that
+authenticated remote.
+
+The executor starts from a clean checkout, stages dependency manifests and lockfiles at any depth,
+plus Yarn Berry PnP/cache artifacts, and rejects tracked, staged, or untracked changes outside that
+allowlist. Verification-generated drift therefore fails the lane instead of being silently included
+or left behind.
+
+Freshness is plan-only in this pilot. The CLI rejects `--track freshness --execute` until it can
+resolve registry candidates and enforce the canonical minimum-age policy before changing a repo.
+Release-track execution remains available for explicitly supplied React on Rails package versions.
+
+The executor is not yet a release gate. It does not poll hosted CI, discover CPFlow review-app
+URLs, run behavioral browser smoke, update the tracking issue, or make a go/no-go decision. Those
+steps remain in the canonical React on Rails release process and its copy/paste batch prompts.
+
+## Verification
+
+```bash
+ruby -Ilib test/demo_fleet_test.rb
+script/demo-fleet validate
+script/demo-fleet update-plan --track freshness
+```
+
+The Ruby runtime uses only the standard library. The default manifest validation requires network
+access; tests pass local temporary manifests and are deterministic. When every canonical entry is
+still pending verification, hosted dry-runs report an intentionally empty plan and mutating execution
+refuses to run it.

--- a/docs/demo-fleet-control-plane-design.md
+++ b/docs/demo-fleet-control-plane-design.md
@@ -41,6 +41,12 @@ Mutating runs require an authenticated GitHub CLI. Fresh checkouts use its confi
 so the same path works for public and private fleet repositories and later pushes retain that
 authenticated remote.
 
+The canonical manifest is also a trusted execution boundary. During `execute-plan --execute`, its
+verified repository commands run through a shell in the operator's environment. Anyone who can land
+a manifest change can therefore affect commands run during a fleet update. Keep manifest changes
+reviewed and mutation manually initiated until the control plane adds integrity pinning or a separate
+approval boundary.
+
 The executor starts from a clean checkout, stages dependency manifests and lockfiles at any depth,
 plus Yarn Berry PnP/cache artifacts, and rejects tracked, staged, or untracked changes outside that
 allowlist. Verification-generated drift therefore fails the lane instead of being silently included

--- a/docs/prompts/demo-fleet-update-agent.md
+++ b/docs/prompts/demo-fleet-update-agent.md
@@ -1,0 +1,10 @@
+# Demo Fleet Agent Prompts
+
+Copy/paste release prompts live with the release policy in the canonical
+[`RC Testing Plan`](https://github.com/shakacode/react_on_rails/blob/main/internal/contributor-info/rc-testing-plan.md).
+They are filled with exact release versions, tag and commit evidence, tracking issue, owned lanes,
+model routing, privacy constraints, and merge authority.
+
+Do not keep a release prompt template in this repository. A generic placeholder prompt is too easy
+to launch with stale versions or the wrong fleet snapshot. Use this runtime to render a mechanical
+plan, then use the current release's filled prompt from `react_on_rails` to coordinate the work.

--- a/docs/runbooks/release-gate.md
+++ b/docs/runbooks/release-gate.md
@@ -1,0 +1,101 @@
+# Runtime Runbook
+
+## Release Track
+
+Use this runtime only after selecting the current filled release prompt from the canonical
+[`React on Rails RC Testing Plan`](https://github.com/shakacode/react_on_rails/blob/main/internal/contributor-info/rc-testing-plan.md).
+That plan—not this repository—defines which apps block a final release and what evidence is required.
+
+```bash
+script/demo-fleet validate
+script/demo-fleet execute-plan \
+  --track release \
+  --dry-run \
+  --gem react_on_rails=17.0.0.rc.10 \
+  --gem react_on_rails_pro=17.0.0.rc.10 \
+  --npm react-on-rails=17.0.0-rc.10 \
+  --npm react-on-rails-pro=17.0.0-rc.10 \
+  --npm react-on-rails-pro-node-renderer=17.0.0-rc.10 \
+  --npm react-on-rails-rsc=19.2.1-rc.1
+```
+
+This example is historical RC.10 data. For a current release, copy the exact version block from the
+filled canonical prompt rather than editing this command by pattern.
+
+## Freshness Track
+
+Use this weekly to pull in normal ecosystem updates and expose breakage early.
+
+```bash
+script/demo-fleet validate
+script/demo-fleet update-plan --track freshness
+```
+
+The pilot intentionally keeps freshness in dry-run mode. `--track freshness --execute` is rejected
+until registry candidate resolution applies the canonical age policy before changing a repo.
+Future freshness PRs must respect that policy. For pnpm demos, also enforce `minimumReleaseAge` in
+the demo repo.
+
+Repos marked `verify: true` in the canonical manifest are omitted from both tracks. Clear that marker
+in `react_on_rails` only after confirming the repo metadata, including
+`review_app.cpflow_app_name` or an explicit `review_app: null` opt-out. Gem targets must exist in the
+root `Gemfile`. npm targets are updated in direct `package.json` declarations at any supported depth; packages that are intentionally
+transitive-only must be named in `transitive_only_npm_packages`. Each changed manifest gets its own
+package-manager install so its adjacent lockfile is refreshed.
+
+For Pro-only apps, the base `react_on_rails` and `react-on-rails` targets may remain in the canonical
+release set even when only `react_on_rails_pro` and `react-on-rails-pro` are declared directly. The
+updater recognizes those two base packages as implied Pro dependencies; every other missing target
+still requires explicit transitive-only metadata or fails closed.
+
+Dry-runs with no actionable repositories succeed with a zero-repository report, allowing the hosted
+release-plan workflow to remain usable during one-time manifest verification. Mutating execution
+still rejects an empty selection.
+
+Use the CLI age gate for one version timestamp:
+
+```bash
+script/demo-fleet age-check \
+  --ecosystem rubygems \
+  --package rails \
+  --created-at 2026-05-20T00:00:00Z \
+  --track freshness
+```
+
+## Current Pilot Boundary
+
+Execution requires an authenticated GitHub CLI. Fresh checkouts use `gh repo clone`, which preserves
+the operator's configured HTTPS or SSH protocol and supports private fleet repositories such as
+HiChee.
+
+Start any pilot without remote writes:
+
+```bash
+script/demo-fleet execute-plan \
+  --track release \
+  --repo react-on-rails-demo-marketplace-rsc \
+  --execute \
+  --workspace /tmp/demo-fleet-pilot \
+  --gem react_on_rails=17.0.0.rc.10 \
+  --gem react_on_rails_pro=17.0.0.rc.10 \
+  --npm react-on-rails=17.0.0-rc.10 \
+  --npm react-on-rails-pro=17.0.0-rc.10 \
+  --npm react-on-rails-pro-node-renderer=17.0.0-rc.10 \
+  --npm react-on-rails-rsc=19.2.1-rc.1
+```
+
+After inspecting the local branch and commit, repeat with `--allow-remote-prs` only when the active
+release prompt and coordination state authorize that lane. Hosted CI, review-app deployment,
+behavioral smoke, review resolution, tracking evidence, and merging remain outside this pilot
+executor.
+
+## Triage
+
+When a demo fails, classify it in the release issue:
+
+- Product regression in React on Rails, ShakaPacker, or CPFlow.
+- Demo-specific upgrade work.
+- Third-party dependency breakage.
+- Infrastructure failure.
+
+The canonical tracking issue and RC plan decide whether a failure blocks release.

--- a/lib/demo_fleet.rb
+++ b/lib/demo_fleet.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'demo_fleet/dependency_file_updater'
+require_relative 'demo_fleet/executor'
+require_relative 'demo_fleet/manifest'
+require_relative 'demo_fleet/review_app'
+require_relative 'demo_fleet/runner'
+require_relative 'demo_fleet/supply_chain_policy'
+require_relative 'demo_fleet/update_planner'
+require_relative 'demo_fleet/cli'

--- a/lib/demo_fleet/cli.rb
+++ b/lib/demo_fleet/cli.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'optparse'
+require 'time'
+require 'tmpdir'
+
+module DemoFleet
+  class CLI
+    DEFAULT_MANIFEST = ENV.fetch(
+      'DEMO_FLEET_MANIFEST',
+      'https://raw.githubusercontent.com/shakacode/react_on_rails/main/internal/contributor-info/demo-fleet.yml'
+    )
+
+    def self.run(argv, out: $stdout, err: $stderr)
+      new(argv, out: out, err: err).run
+    end
+
+    def initialize(argv, out:, err:)
+      @argv = argv.dup
+      @out = out
+      @err = err
+    end
+
+    def run
+      command = @argv.shift
+
+      case command
+      when 'validate'
+        validate
+      when 'update-plan'
+        update_plan
+      when 'execute-plan'
+        execute_plan
+      when 'age-check'
+        age_check
+      when 'help', nil
+        @out.puts(help)
+        0
+      else
+        @err.puts("Unknown command: #{command}")
+        @err.puts(help)
+        1
+      end
+    rescue OptionParser::ParseError, ArgumentError, KeyError => e
+      @err.puts(e.message)
+      1
+    end
+
+    private
+
+    def validate
+      options = { manifest: DEFAULT_MANIFEST }
+      parser = OptionParser.new do |opts|
+        opts.banner = 'Usage: script/demo-fleet validate [options]'
+        opts.on('--manifest PATH', 'Path to demo fleet manifest') { |value| options[:manifest] = value }
+      end
+      parser.parse!(@argv)
+
+      manifest = Manifest.from_source(options[:manifest])
+      @out.puts(
+        "Manifest valid: #{manifest.enabled_repos.length} actionable repos, " \
+        "#{manifest.pending_verification_repos.length} pending verification, #{manifest.repos.length} total repos"
+      )
+      0
+    end
+
+    def update_plan
+      options = {
+        manifest: DEFAULT_MANIFEST,
+        rubygems_versions: {},
+        npm_versions: {},
+        track: 'freshness',
+        date: Date.today,
+        tier: nil,
+        repo_id: nil
+      }
+
+      parser = OptionParser.new do |opts|
+        opts.banner = 'Usage: script/demo-fleet update-plan [options]'
+        opts.on('--manifest PATH', 'Path to demo fleet manifest') { |value| options[:manifest] = value }
+        opts.on('--track TRACK', 'Run track: release or freshness') { |value| options[:track] = value }
+        opts.on('--tier TIER', 'Only include repos in this tier') { |value| options[:tier] = value }
+        opts.on('--repo ID', 'Only include one repo id') { |value| options[:repo_id] = value }
+        opts.on('--date YYYY-MM-DD', 'Date used for branch names') { |value| options[:date] = Date.iso8601(value) }
+        opts.on('--gem NAME=VERSION', 'Target RubyGem version; repeatable') do |value|
+          name, version = parse_assignment(value)
+          options[:rubygems_versions][name] = version
+        end
+        opts.on('--npm NAME=VERSION', 'Target npm version; repeatable') do |value|
+          name, version = parse_assignment(value)
+          options[:npm_versions][name] = version
+        end
+      end
+      parser.parse!(@argv)
+
+      manifest = Manifest.from_source(options[:manifest])
+      planner = UpdatePlanner.new(
+        manifest: manifest,
+        rubygems_versions: options[:rubygems_versions],
+        npm_versions: options[:npm_versions],
+        track: options[:track],
+        date: options[:date],
+        tier: options[:tier],
+        repo_id: options[:repo_id]
+      )
+
+      @out.puts(planner.to_markdown)
+      0
+    end
+
+    def execute_plan
+      options = {
+        manifest: DEFAULT_MANIFEST,
+        rubygems_versions: {},
+        npm_versions: {},
+        track: 'freshness',
+        date: Date.today,
+        tier: nil,
+        repo_id: nil,
+        dry_run: false,
+        execute: false,
+        concurrency: nil,
+        workspace: nil,
+        allow_remote_prs: false
+      }
+
+      parser = OptionParser.new do |opts|
+        opts.banner = 'Usage: script/demo-fleet execute-plan [options] (--dry-run | --execute --workspace PATH)'
+        opts.on('--manifest PATH', 'Path to demo fleet manifest') { |value| options[:manifest] = value }
+        opts.on('--track TRACK', 'Run track: release or freshness') { |value| options[:track] = value }
+        opts.on('--tier TIER', 'Only include repos in this tier') { |value| options[:tier] = value }
+        opts.on('--repo ID', 'Only include one repo id') { |value| options[:repo_id] = value }
+        opts.on('--date YYYY-MM-DD', 'Date used for branch names') { |value| options[:date] = Date.iso8601(value) }
+        opts.on('--concurrency N', Integer, 'Number of repos to process in parallel') do |value|
+          options[:concurrency] = value
+        end
+        opts.on('--dry-run', 'Render and validate per-repo work without mutating demo repos') do
+          options[:dry_run] = true
+        end
+        opts.on('--execute', 'Clone/update local demo checkouts') { options[:execute] = true }
+        opts.on('--workspace PATH', 'Workspace for local demo repo checkouts') { |value| options[:workspace] = value }
+        opts.on('--allow-remote-prs', 'Allow git push and gh pr create commands during --execute') do
+          options[:allow_remote_prs] = true
+        end
+        opts.on('--gem NAME=VERSION', 'Target RubyGem version; repeatable') do |value|
+          name, version = parse_assignment(value)
+          options[:rubygems_versions][name] = version
+        end
+        opts.on('--npm NAME=VERSION', 'Target npm version; repeatable') do |value|
+          name, version = parse_assignment(value)
+          options[:npm_versions][name] = version
+        end
+      end
+      parser.parse!(@argv)
+
+      validate_execute_plan_mode!(options)
+
+      manifest = Manifest.from_source(options[:manifest])
+      planner = UpdatePlanner.new(
+        manifest: manifest,
+        rubygems_versions: options[:rubygems_versions],
+        npm_versions: options[:npm_versions],
+        track: options[:track],
+        date: options[:date],
+        tier: options[:tier],
+        repo_id: options[:repo_id]
+      )
+
+      if planner.plans.empty?
+        if options[:dry_run]
+          @out.puts(execution_report([], track: options[:track], dry_run: true))
+          return 0
+        end
+
+        raise ArgumentError, 'no verified, enabled repositories matched this execution'
+      end
+
+      executor = Executor.new(workspace: options[:workspace] || Dir.tmpdir,
+                              allow_remote_prs: options[:allow_remote_prs])
+      runner = Runner.new(concurrency: options[:concurrency] || manifest.concurrency) do |plan|
+        options[:dry_run] ? dry_run_plan(plan, executor) : executor.execute(plan)
+      end
+
+      results = runner.run(planner.plans)
+      @out.puts(execution_report(results, track: options[:track], dry_run: options[:dry_run]))
+
+      results.all? { |result| result.status == 'success' } ? 0 : 2
+    end
+
+    def age_check
+      options = {
+        manifest: DEFAULT_MANIFEST,
+        policy: nil,
+        track: 'freshness',
+        targeted: false,
+        now: Time.now.utc
+      }
+
+      parser = OptionParser.new do |opts|
+        opts.banner = 'Usage: script/demo-fleet age-check [options]'
+        opts.on('--manifest PATH_OR_URL', 'Canonical manifest source') { |value| options[:manifest] = value }
+        opts.on('--policy PATH', 'Legacy standalone supply-chain policy') { |value| options[:policy] = value }
+        opts.on('--ecosystem NAME', 'rubygems or npm') { |value| options[:ecosystem] = value }
+        opts.on('--package NAME', 'Package name') { |value| options[:package_name] = value }
+        opts.on('--created-at TIME', 'Package version creation timestamp') do |value|
+          options[:created_at] = Time.parse(value)
+        end
+        opts.on('--track TRACK', 'Run track') { |value| options[:track] = value }
+        opts.on('--now TIME', 'Current time override') { |value| options[:now] = Time.parse(value) }
+        opts.on('--targeted', 'Treat package as explicitly targeted by this train') { options[:targeted] = true }
+      end
+      parser.parse!(@argv)
+
+      required_options = { ecosystem: '--ecosystem', package_name: '--package', created_at: '--created-at' }
+      required_options.each do |key, flag|
+        raise ArgumentError, "#{flag} is required" unless options[key]
+      end
+
+      policy = if options[:policy]
+                 SupplyChainPolicy.from_file(options[:policy])
+               else
+                 SupplyChainPolicy.from_manifest(Manifest.from_source(options[:manifest]))
+               end
+      allowed = policy.allows_version?(
+        ecosystem: options[:ecosystem],
+        package_name: options[:package_name],
+        created_at: options[:created_at],
+        track: options[:track],
+        now: options[:now],
+        targeted: options[:targeted]
+      )
+
+      if allowed
+        @out.puts("#{options[:ecosystem]} #{options[:package_name]} allowed by age policy")
+        0
+      else
+        @err.puts("#{options[:ecosystem]} #{options[:package_name]} blocked by age policy")
+        2
+      end
+    end
+
+    def parse_assignment(value)
+      name, version = value.split('=', 2)
+      raise ArgumentError, "Expected NAME=VERSION, got #{value.inspect}" if name.to_s.empty? || version.to_s.empty?
+
+      [name, version]
+    end
+
+    def validate_execute_plan_mode!(options)
+      raise ArgumentError, 'choose exactly one of --dry-run or --execute' if options[:dry_run] == options[:execute]
+
+      if options[:execute] && options[:workspace].to_s.strip.empty?
+        raise ArgumentError,
+              '--workspace is required for --execute'
+      end
+
+      return unless options[:execute] && options[:track] == 'freshness'
+
+      raise ArgumentError,
+            'freshness execution is disabled until registry candidate age-gate enforcement is implemented; ' \
+            'use --dry-run'
+    end
+
+    def dry_run_plan(plan, executor)
+      executor.commands_for(plan)
+      plan
+    end
+
+    def execution_report(results, track:, dry_run:)
+      lines = [
+        '# Demo Fleet Execution Plan',
+        '',
+        "- Track: `#{track}`",
+        "- Mode: `#{dry_run ? 'dry-run' : 'execute'}`",
+        "- Repositories: `#{results.length}`",
+        '',
+        '| Repo | Status | Branch |',
+        '| --- | --- | --- |'
+      ]
+
+      results.each do |result|
+        branch = result.value.respond_to?(:branch_name) ? result.value.branch_name : '-'
+        lines << "| `#{result.repo_id}` | `#{result.status}` | `#{branch}` |"
+      end
+
+      failures = results.reject { |result| result.status == 'success' }
+      if failures.any?
+        lines.push('', 'Failures:')
+        failures.each { |result| lines << "- `#{result.repo_id}`: #{result.error}" }
+      end
+
+      lines.join("\n")
+    end
+
+    def help
+      <<~HELP
+        Demo Fleet controls cross-repo dependency update planning for ShakaCode demo apps.
+        By default it reads the canonical manifest from shakacode/react_on_rails.
+
+        Commands:
+          validate      Validate the canonical demo fleet manifest
+          update-plan   Render a Markdown update plan for selected demos
+          execute-plan  Render and validate per-repo work in dry-run mode
+          age-check     Check one package version timestamp against policy
+
+        Examples:
+          script/demo-fleet validate
+          script/demo-fleet update-plan --track release --gem react_on_rails=17.0.0.rc.0 --gem react_on_rails_pro=17.0.0.rc.0 --gem shakapacker=10.1.0 --gem cpflow=5.0.4 --npm react-on-rails=17.0.0-rc.0 --npm react-on-rails-pro=17.0.0-rc.0 --npm react-on-rails-pro-node-renderer=17.0.0-rc.0 --npm react-on-rails-rsc=19.0.5-rc.3 --npm shakapacker=10.1.0
+          script/demo-fleet update-plan --track freshness
+          script/demo-fleet execute-plan --track release --repo marketplace-rsc --execute --workspace /tmp/demo-fleet-pilot
+          script/demo-fleet age-check --ecosystem npm --package react --created-at 2026-05-20T00:00:00Z --track freshness
+      HELP
+    end
+  end
+end

--- a/lib/demo_fleet/dependency_file_updater.rb
+++ b/lib/demo_fleet/dependency_file_updater.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'find'
+require 'ripper'
 
 module DemoFleet
   class DependencyFileUpdater
@@ -113,7 +114,7 @@ module DemoFleet
         end
 
         statement_lines = extract_gem_statement(lines, index)
-        replacement = rewritten_gem_statement(statement_lines.join(' '), name, version, indent: lines[index][/^\s*/])
+        replacement = rewritten_gem_statement(statement_lines.join, name, version, indent: lines[index][/^\s*/])
         lines[index, statement_lines.length] = [replacement]
         replacements += 1
         index += 1
@@ -124,7 +125,7 @@ module DemoFleet
 
     def extract_gem_statement(lines, index)
       statement_lines = [lines[index]]
-      while statement_lines.last.rstrip.end_with?(',') &&
+      while Ripper.sexp(statement_lines.join).nil? &&
             lines[index + statement_lines.length]&.match?(/^\s+(?!gem\b)\S/)
         statement_lines << lines[index + statement_lines.length]
       end
@@ -132,7 +133,10 @@ module DemoFleet
     end
 
     def rewritten_gem_statement(statement, name, version, indent: '')
-      body = statement.sub(/^\s*gem\s+["']#{Regexp.escape(name)}["']\s*,?/, '')
+      tokens = Ripper.lex(statement)
+      tokens.reject! { |_position, event, _token| event == :on_comment }
+      uncommented_statement = tokens.map { |_position, _event, token| token }.join
+      body = uncommented_statement.sub(/^\s*gem\s+["']#{Regexp.escape(name)}["']\s*,?/, '')
       options = split_ruby_arguments(body).select { |argument| preserved_gem_option?(argument) }
       suffix = options.empty? ? '' : ", #{options.join(', ')}"
       "#{indent}gem '#{name}', '#{version}'#{suffix}\n"

--- a/lib/demo_fleet/dependency_file_updater.rb
+++ b/lib/demo_fleet/dependency_file_updater.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'find'
+
+module DemoFleet
+  class DependencyFileUpdater
+    GEM_SOURCE_OPTIONS = %w[git github path branch tag ref glob].freeze
+    PACKAGE_JSON_SECTIONS = %w[
+      dependencies
+      devDependencies
+      optionalDependencies
+      peerDependencies
+      overrides
+      resolutions
+    ].freeze
+
+    IGNORED_DIRECTORIES = %w[.git node_modules vendor tmp log storage].freeze
+    IMPLIED_GEM_TARGETS = { 'react_on_rails' => 'react_on_rails_pro' }.freeze
+    IMPLIED_NPM_TARGETS = { 'react-on-rails' => 'react-on-rails-pro' }.freeze
+
+    attr_reader :root, :rubygems_versions, :npm_versions, :allowed_missing_npm_targets
+
+    def initialize(root:, rubygems_versions:, npm_versions:, allowed_missing_npm_targets: [])
+      @root = File.expand_path(root)
+      @rubygems_versions = rubygems_versions.transform_keys(&:to_s)
+      @npm_versions = npm_versions.transform_keys(&:to_s)
+      @allowed_missing_npm_targets = Array(allowed_missing_npm_targets).map(&:to_s).freeze
+    end
+
+    def apply
+      validate_targets!
+      update_gemfile if rubygems_versions.any?
+      update_package_json if npm_versions.any?
+    end
+
+    private
+
+    def validate_targets!
+      validate_gem_targets! if rubygems_versions.any?
+      validate_npm_targets! if npm_versions.any?
+    end
+
+    def validate_gem_targets!
+      path = File.join(root, 'Gemfile')
+      raise ArgumentError, "Gemfile not found at #{path}" unless File.exist?(path)
+
+      contents = File.read(path)
+      rubygems_versions.each_key do |name|
+        next if gem_declared?(contents, name)
+        next if implied_gem_target?(contents, name)
+
+        raise ArgumentError, "gem #{name.inspect} is not declared in #{path}"
+      end
+    end
+
+    def validate_npm_targets!
+      paths = package_json_paths
+      raise ArgumentError, "package.json not found under #{root}" if paths.empty?
+
+      manifests = paths.to_h { |path| [path, JSON.parse(File.read(path))] }
+      npm_versions.each_key do |name|
+        next if manifests.any? { |_path, data| npm_package_declared?(data, name) }
+        next if implied_npm_target?(manifests, name)
+        next if allowed_missing_npm_targets.include?(name)
+
+        raise ArgumentError, "npm package #{name.inspect} is not declared under #{root}"
+      end
+    end
+
+    def npm_package_declared?(data, name)
+      PACKAGE_JSON_SECTIONS.any? { |section| data[section].is_a?(Hash) && data[section].key?(name) } ||
+        (data.dig('pnpm', 'overrides').is_a?(Hash) && data.dig('pnpm', 'overrides').key?(name))
+    end
+
+    def gem_declared?(contents, name)
+      contents.match?(/^\s*gem\s+["']#{Regexp.escape(name)}["'](?:\s|,)/)
+    end
+
+    def implied_gem_target?(contents, name)
+      pro_package = IMPLIED_GEM_TARGETS[name]
+      pro_package && gem_declared?(contents, pro_package)
+    end
+
+    def implied_npm_target?(manifests, name)
+      pro_package = IMPLIED_NPM_TARGETS[name]
+      pro_package && manifests.any? { |_path, data| npm_package_declared?(data, pro_package) }
+    end
+
+    def update_gemfile
+      path = File.join(root, 'Gemfile')
+      raise ArgumentError, "Gemfile not found at #{path}" unless File.exist?(path)
+
+      lines = File.readlines(path)
+      rubygems_versions.each do |name, version|
+        replacements = replace_gem_line(lines, name, version)
+        next if replacements.zero? && implied_gem_target?(lines.join, name)
+
+        raise ArgumentError, "gem #{name.inspect} is not declared in #{path}" if replacements.zero?
+      end
+      File.write(path, lines.join)
+    end
+
+    def replace_gem_line(lines, name, version)
+      pattern = /^\s*gem\s+["']#{Regexp.escape(name)}["'](?:\s|,)/
+      index = 0
+      replacements = 0
+
+      while index < lines.length
+        unless lines[index].match?(pattern)
+          index += 1
+          next
+        end
+
+        statement_lines = extract_gem_statement(lines, index)
+        replacement = rewritten_gem_statement(statement_lines.join(' '), name, version, indent: lines[index][/^\s*/])
+        lines[index, statement_lines.length] = [replacement]
+        replacements += 1
+        index += 1
+      end
+
+      replacements
+    end
+
+    def extract_gem_statement(lines, index)
+      statement_lines = [lines[index]]
+      while statement_lines.last.rstrip.end_with?(',') &&
+            lines[index + statement_lines.length]&.match?(/^\s+(?!gem\b)\S/)
+        statement_lines << lines[index + statement_lines.length]
+      end
+      statement_lines
+    end
+
+    def rewritten_gem_statement(statement, name, version, indent: '')
+      body = statement.sub(/^\s*gem\s+["']#{Regexp.escape(name)}["']\s*,?/, '')
+      options = split_ruby_arguments(body).select { |argument| preserved_gem_option?(argument) }
+      suffix = options.empty? ? '' : ", #{options.join(', ')}"
+      "#{indent}gem '#{name}', '#{version}'#{suffix}\n"
+    end
+
+    def split_ruby_arguments(source)
+      arguments = []
+      current = +''
+      quote = nil
+      escaped = false
+      depth = 0
+
+      source.each_char do |character|
+        if quote
+          current << character
+          if escaped
+            escaped = false
+          elsif character == '\\'
+            escaped = true
+          elsif character == quote
+            quote = nil
+          end
+        elsif %w[' "].include?(character)
+          quote = character
+          current << character
+        elsif '([{'.include?(character)
+          depth += 1
+          current << character
+        elsif ')]}'.include?(character)
+          depth -= 1
+          current << character
+        elsif character == ',' && depth.zero?
+          arguments << current.strip unless current.strip.empty?
+          current = +''
+        else
+          current << character
+        end
+      end
+
+      arguments << current.strip unless current.strip.empty?
+      arguments
+    end
+
+    def preserved_gem_option?(argument)
+      match = argument.match(/\A(?:([a-zA-Z_]\w*):|:([a-zA-Z_]\w*)\s*=>)/)
+      key = match && (match[1] || match[2])
+      key && !GEM_SOURCE_OPTIONS.include?(key)
+    end
+
+    def update_package_json
+      replacements = npm_versions.to_h { |name, _version| [name, 0] }
+      package_json_paths.each { |path| update_package_json_file(path, replacements) }
+      validate_npm_replacements!(replacements)
+    end
+
+    def update_package_json_file(path, replacements)
+      data = JSON.parse(File.read(path))
+      changed = false
+      npm_versions.each do |name, version|
+        count = update_package_in_known_sections(data, name, version)
+        count += update_package_in_pnpm_overrides(data, name, version)
+        replacements[name] += count
+        changed ||= count.positive?
+      end
+      File.write(path, "#{JSON.pretty_generate(data)}\n") if changed
+    end
+
+    def validate_npm_replacements!(replacements)
+      missing = replacements.select { |_name, count| count.zero? }.keys
+      manifests = package_json_paths.to_h { |path| [path, JSON.parse(File.read(path))] }
+      missing.reject! { |name| implied_npm_target?(manifests, name) }
+      missing -= allowed_missing_npm_targets
+      return if missing.empty?
+
+      raise ArgumentError, "npm packages are not declared under #{root}: #{missing.join(', ')}"
+    end
+
+    def package_json_paths
+      paths = []
+      Find.find(root) do |path|
+        if File.directory?(path) && path != root && IGNORED_DIRECTORIES.include?(File.basename(path))
+          Find.prune
+        elsif File.file?(path) && File.basename(path) == 'package.json'
+          paths << path
+        end
+      end
+      paths.sort
+    end
+
+    def update_package_in_known_sections(data, name, version)
+      PACKAGE_JSON_SECTIONS.count do |section|
+        next false unless data[section].is_a?(Hash) && data[section].key?(name)
+
+        data[section][name] = version
+        true
+      end
+    end
+
+    def update_package_in_pnpm_overrides(data, name, version)
+      overrides = data.fetch('pnpm', {})['overrides']
+      return 0 unless overrides.is_a?(Hash) && overrides.key?(name)
+
+      overrides[name] = version
+      1
+    end
+  end
+end

--- a/lib/demo_fleet/executor.rb
+++ b/lib/demo_fleet/executor.rb
@@ -71,11 +71,13 @@ module DemoFleet
             echo "local and remote update branches have diverged: $1" >&2
             exit 1
           fi
-        # A local-only pilot branch tracks origin/HEAD until it is published. Preserve it so the
-        # inspected first-pass commit is the exact commit pushed by a later --allow-remote-prs run.
         elif [[ "$(git config --get branch.$1.remote)" == origin ]] &&
              [[ "$(git config --get branch.$1.merge)" == "refs/heads/$1" ]]; then
-          exec git checkout -B "$1" origin/HEAD
+          if git merge-base --is-ancestor "$1" origin/HEAD; then
+            exec git checkout -B "$1" origin/HEAD
+          fi
+          echo "remote update branch was deleted but local branch contains commits not in origin/HEAD: $1" >&2
+          exit 1
         fi
       elif git show-ref --verify --quiet "refs/remotes/origin/$1"; then
         exec git checkout --track -b "$1" "origin/$1"

--- a/lib/demo_fleet/executor.rb
+++ b/lib/demo_fleet/executor.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+require 'open3'
+
+module DemoFleet
+  ShellCommand = Struct.new(:argv, :cwd, :description, :phase, keyword_init: true) do
+    def to_s
+      prefix = cwd ? "(cd #{Shellwords.escape(cwd)} && " : ''
+      suffix = cwd ? ')' : ''
+      "#{prefix}#{argv.shelljoin}#{suffix}"
+    end
+  end
+
+  ExecutionOutcome = Struct.new(:repo_id, :branch_name, :commands, keyword_init: true)
+
+  class Shell
+    def call(command)
+      ok = if command.cwd
+             system(*command.argv, chdir: command.cwd)
+           else
+             system(*command.argv)
+           end
+
+      raise "command failed: #{command}" unless ok
+    end
+
+    def staged_changes?(cwd)
+      !system('git', 'diff', '--cached', '--quiet', chdir: cwd, out: File::NULL, err: File::NULL)
+    end
+
+    def branch_has_commits?(cwd)
+      upstream, upstream_status = Open3.capture2(
+        'git', 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}', chdir: cwd
+      )
+      base = upstream_status.success? ? upstream.strip : 'origin/HEAD'
+      output, status = Open3.capture2('git', 'rev-list', '--count', "#{base}..HEAD", chdir: cwd)
+      status.success? && output.to_i.positive?
+    end
+
+    def branch_has_release_commits?(cwd)
+      output, status = Open3.capture2('git', 'rev-list', '--count', 'origin/HEAD..HEAD', chdir: cwd)
+      status.success? && output.to_i.positive?
+    end
+  end
+
+  class Executor
+    REPO_ROOT = File.expand_path('../..', __dir__)
+    VERIFY_TEMPLATE_TARGET = 'script/demo-fleet-verify'
+    DEPENDENCY_PATHS = %w[
+      Gemfile
+      Gemfile.lock
+      package.json
+      package-lock.json
+      npm-shrinkwrap.json
+      yarn.lock
+      pnpm-lock.yaml
+      .pnp.cjs
+      .pnp.loader.mjs
+      .yarn/cache/*
+      .yarn/install-state.gz
+      script/demo-fleet-verify
+    ].freeze
+    CHECKOUT_BRANCH_SCRIPT = <<~BASH
+      if git show-ref --verify --quiet "refs/heads/$1"; then
+        git checkout "$1"
+        if git show-ref --verify --quiet "refs/remotes/origin/$1"; then
+          if git merge-base --is-ancestor "$1" "origin/$1"; then
+            exec git merge --ff-only "origin/$1"
+          elif ! git merge-base --is-ancestor "origin/$1" "$1"; then
+            echo "local and remote update branches have diverged: $1" >&2
+            exit 1
+          fi
+        # A local-only pilot branch tracks origin/HEAD until it is published. Preserve it so the
+        # inspected first-pass commit is the exact commit pushed by a later --allow-remote-prs run.
+        elif [[ "$(git config --get branch.$1.remote)" == origin ]] &&
+             [[ "$(git config --get branch.$1.merge)" == "refs/heads/$1" ]]; then
+          exec git checkout -B "$1" origin/HEAD
+        fi
+      elif git show-ref --verify --quiet "refs/remotes/origin/$1"; then
+        exec git checkout --track -b "$1" "origin/$1"
+      else
+        exec git checkout -b "$1" origin/HEAD
+      fi
+    BASH
+    STAGE_DEPENDENCY_FILES_SCRIPT = <<~BASH
+      allowed_path() {
+        case "$1" in
+          __DEPENDENCY_PATH_PATTERNS__) return 0 ;;
+          *) return 1 ;;
+        esac
+      }
+
+      changed=()
+      unexpected=()
+      while IFS= read -r -d '' path; do
+        changed+=("$path")
+        allowed_path "$path" || unexpected+=("$path")
+      done < <(
+        git diff --name-only -z
+        git diff --cached --name-only -z
+        git ls-files --others --exclude-standard -z
+      )
+      if ((${#unexpected[@]} > 0)); then
+        echo "files outside the dependency allowlist changed: ${unexpected[*]}" >&2
+        exit 1
+      fi
+
+      ((${#changed[@]} == 0)) || exec git add --all -- "${changed[@]}"
+    BASH
+
+    attr_reader :workspace, :allow_remote_prs, :shell
+
+    def initialize(workspace:, allow_remote_prs: false, shell: Shell.new)
+      @workspace = File.expand_path(workspace)
+      @allow_remote_prs = allow_remote_prs
+      @shell = shell
+    end
+
+    def execute(plan)
+      commands = commands_for(plan)
+      executed_commands = commands.select do |command|
+        next false unless run_command?(command)
+
+        shell.call(command)
+        true
+      end
+      ExecutionOutcome.new(repo_id: plan.repo.id, branch_name: plan.branch_name, commands: executed_commands)
+    end
+
+    def commands_for(plan)
+      repo_path = File.join(workspace, plan.repo.id)
+      commands = [command(['mkdir', '-p', workspace], description: 'Create executor workspace')]
+      commands.concat(checkout_commands(plan, repo_path))
+
+      commands.concat(mise_trust_commands(plan.repo, repo_path))
+      commands.concat(verify_template_commands(plan.repo, repo_path))
+
+      plan.dependency_commands.each do |dependency_command|
+        argv = repo_command_argv(plan.repo, Shellwords.split(dependency_command))
+        commands << command(argv, cwd: repo_path, description: 'Update dependency')
+      end
+
+      plan.verify_commands.each do |verify_command|
+        argv = repo_command_argv(plan.repo, ['bash', '-lc', verify_command])
+        commands << command(argv, cwd: repo_path, description: 'Run demo verification')
+      end
+
+      commands.concat(local_git_commands(plan, repo_path))
+      commands.concat(remote_pr_commands(plan, repo_path)) if allow_remote_prs
+      commands
+    end
+
+    private
+
+    def run_command?(command)
+      case command.phase
+      when :commit
+        shell.staged_changes?(command.cwd)
+      when :push
+        shell.branch_has_commits?(command.cwd)
+      when :open_pr
+        shell.branch_has_release_commits?(command.cwd)
+      else
+        true
+      end
+    end
+
+    def checkout_commands(plan, repo_path)
+      commands = if File.directory?(File.join(repo_path, '.git'))
+                   [verify_origin_command(plan.repo, repo_path),
+                    clean_checkout_command(repo_path),
+                    command(%w[git fetch --prune origin], cwd: repo_path, description: 'Update demo checkout')]
+                 else
+                   [command(['gh', 'repo', 'clone', plan.repo.github, repo_path],
+                            description: 'Clone demo repo')]
+                 end
+
+      commands << checkout_branch_command(plan, repo_path)
+      commands << clean_checkout_command(repo_path) unless File.directory?(File.join(repo_path, '.git'))
+      commands
+    end
+
+    def verify_origin_command(repo, repo_path)
+      script = <<~BASH
+        origin="$(git remote get-url origin)"
+        case "$origin" in
+          "https://github.com/$1"|"https://github.com/$1.git"|https://*@"github.com/$1"|\
+          https://*@"github.com/$1.git"|"git@github.com:$1"|"git@github.com:$1.git"|\
+          "ssh://git@github.com/$1"|"ssh://git@github.com/$1.git")
+            ;;
+          *)
+            echo "origin remote does not match expected repository $1" >&2
+            exit 1
+            ;;
+        esac
+      BASH
+      command(
+        ['bash', '-lc', script, 'demo-fleet', repo.github],
+        cwd: repo_path,
+        description: 'Verify demo checkout origin'
+      )
+    end
+
+    def checkout_branch_command(plan, repo_path)
+      command(
+        ['bash', '-lc', CHECKOUT_BRANCH_SCRIPT, 'demo-fleet', plan.branch_name],
+        cwd: repo_path,
+        description: 'Create or reuse update branch'
+      )
+    end
+
+    def clean_checkout_command(repo_path)
+      script = <<~BASH
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo 'demo checkout must be clean before an update run' >&2
+          exit 1
+        fi
+      BASH
+      command(['bash', '-lc', script], cwd: repo_path, description: 'Require a clean demo checkout')
+    end
+
+    def verify_template_commands(repo, repo_path)
+      return [] unless repo.respond_to?(:verify_template) && repo.verify_template
+
+      source = File.expand_path(repo.verify_template, REPO_ROOT)
+      unless source.start_with?("#{REPO_ROOT}/") && File.file?(source)
+        raise ArgumentError, "Verification template must be a file inside #{REPO_ROOT}: #{repo.verify_template.inspect}"
+      end
+
+      target = File.join(repo_path, VERIFY_TEMPLATE_TARGET)
+
+      [
+        command(['mkdir', '-p', File.dirname(target)], description: 'Create verification script directory'),
+        command(['cp', source, target], description: 'Install verification script template'),
+        command(['chmod', '+x', target], description: 'Make verification script executable')
+      ]
+    end
+
+    def mise_trust_commands(repo, repo_path)
+      return [] unless repo.respond_to?(:trust_mise?) && repo.trust_mise?
+
+      [
+        command(['mise', 'trust', File.join(repo_path, 'mise.toml')], description: 'Trust repo mise tool versions')
+      ]
+    end
+
+    def repo_command_argv(repo, argv)
+      return argv unless repo.respond_to?(:trust_mise?) && repo.trust_mise?
+
+      ['mise', 'exec', '--', *argv]
+    end
+
+    def local_git_commands(plan, repo_path)
+      [
+        command(['git', 'status', '--short'], cwd: repo_path, description: 'Show changed files'),
+        stage_dependency_files_command(repo_path),
+        command(['git', 'commit', '-m', commit_message(plan)], cwd: repo_path,
+                                                               description: 'Commit dependency updates', phase: :commit)
+      ]
+    end
+
+    def stage_dependency_files_command(repo_path)
+      script = STAGE_DEPENDENCY_FILES_SCRIPT.sub('__DEPENDENCY_PATH_PATTERNS__', dependency_path_patterns)
+      command(['bash', '-lc', script], cwd: repo_path, description: 'Stage dependency update files')
+    end
+
+    def dependency_path_patterns
+      DEPENDENCY_PATHS.flat_map { |path| [path, "*/#{path}"] }.join('|')
+    end
+
+    def remote_pr_commands(plan, repo_path)
+      [
+        command(['git', 'push', '-u', 'origin', plan.branch_name], cwd: repo_path,
+                                                                   description: 'Push update branch', phase: :push),
+        open_pr_command(plan, repo_path)
+      ]
+    end
+
+    def open_pr_command(plan, repo_path)
+      script = <<~BASH
+        gh pr view "$1" --repo "$2" >/dev/null 2>&1 ||
+          exec gh pr create --repo "$2" --head "$1" --draft --title "$3" --body "$4"
+      BASH
+      command(
+        ['bash', '-lc', script, 'demo-fleet', plan.branch_name, plan.repo.github, pr_title(plan), pr_body(plan)],
+        cwd: repo_path,
+        description: 'Open or reuse draft demo update PR',
+        phase: :open_pr
+      )
+    end
+
+    def commit_message(plan)
+      "chore: update #{plan.repo.id} demo dependencies"
+    end
+
+    def pr_title(plan)
+      "Update #{plan.repo.id} demo dependencies"
+    end
+
+    def pr_body(plan)
+      lines = [
+        'Generated by the demo fleet executor.',
+        '',
+        "Branch: `#{plan.branch_name}`",
+        '',
+        'Dependency commands:'
+      ]
+      lines.concat(plan.dependency_commands.map { |dependency_command| "- `#{dependency_command}`" })
+      lines.push('', 'Verification commands:')
+      lines.concat(plan.verify_commands.map { |verify_command| "- `#{verify_command}`" })
+      lines.push('', 'Smoke URLs:')
+      lines.concat(plan.smoke_urls.map { |smoke_url| "- `#{smoke_url}`" })
+      lines.join("\n")
+    end
+
+    def command(argv, description:, cwd: nil, phase: nil)
+      ShellCommand.new(argv: argv, cwd: cwd, description: description, phase: phase)
+    end
+  end
+end

--- a/lib/demo_fleet/manifest.rb
+++ b/lib/demo_fleet/manifest.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'net/http'
+require 'uri'
+
+module DemoFleet
+  PackageRef = Struct.new(:ecosystem, :name, keyword_init: true) do
+    def initialize(ecosystem:, name:)
+      normalized_ecosystem = ecosystem.to_s
+      unless %w[gem npm].include?(normalized_ecosystem)
+        raise ArgumentError, "Unsupported package ecosystem #{ecosystem.inspect}"
+      end
+      raise ArgumentError, 'Package name is required' if name.to_s.strip.empty?
+
+      super(ecosystem: normalized_ecosystem, name: name.to_s)
+    end
+  end
+
+  ReviewApp = Struct.new(:cpflow_app_name, :cpln_workload_name, :live_url, keyword_init: true) do
+    def initialize(cpflow_app_name: nil, cpln_workload_name: nil, live_url: nil)
+      super(
+        cpflow_app_name: blank_to_nil(cpflow_app_name),
+        cpln_workload_name: blank_to_nil(cpln_workload_name),
+        live_url: blank_to_nil(live_url)
+      )
+    end
+
+    def validate!(repo_id)
+      return unless cpflow_app_name.nil?
+
+      raise ArgumentError,
+            "repo #{repo_id} review_app.cpflow_app_name is required before repo verification is cleared"
+    end
+
+    private
+
+    def blank_to_nil(value)
+      value = value.to_s.strip unless value.nil?
+      value == '' ? nil : value
+    end
+  end
+
+  class Manifest
+    class LoadError < ArgumentError; end
+
+    attr_reader :defaults, :repos, :source
+
+    def self.from_source(source)
+      contents = read_source(source)
+      data = YAML.safe_load(contents, aliases: true, filename: source) || {}
+      new(data, source: source)
+    rescue Psych::Exception => e
+      raise LoadError, "Unable to parse manifest from #{source}: #{e.message}"
+    end
+
+    def self.from_file(path)
+      from_source(path)
+    end
+
+    def self.remote_source?(source)
+      uri = URI.parse(source)
+      %w[http https].include?(uri.scheme)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def self.fetch(source)
+      response = Net::HTTP.get_response(URI(source))
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      raise ArgumentError, "Unable to load manifest from #{source}: HTTP #{response.code}"
+    end
+
+    def self.read_source(source)
+      remote_source?(source) ? fetch(source) : File.read(source)
+    rescue ArgumentError
+      raise
+    rescue StandardError => e
+      raise LoadError, "Unable to load manifest from #{source}: #{e.message}"
+    end
+
+    private_class_method :fetch, :read_source, :remote_source?
+
+    def initialize(data, source: nil)
+      raise ArgumentError, 'manifest root must be a mapping' unless data.is_a?(Hash)
+
+      @source = source
+      @schema_version = data.fetch('schema_version')
+      @defaults = data.fetch('defaults', {})
+      raise ArgumentError, 'defaults must be a mapping' unless defaults.is_a?(Hash)
+
+      @concurrency = data.fetch('concurrency', defaults.fetch('concurrency', 4))
+      raw_repos = data.fetch('repos', [])
+      raise ArgumentError, 'repos must be an array' unless raw_repos.is_a?(Array)
+      raise ArgumentError, 'repo entries must be mappings' unless raw_repos.all?(Hash)
+
+      @repos = raw_repos.map { |repo_data| Repo.new(repo_data, defaults: defaults) }
+      validate!
+    end
+
+    def enabled_repos
+      repos.select { |repo| repo.enabled? && !repo.verification_pending? }
+    end
+
+    def pending_verification_repos
+      repos.select { |repo| repo.enabled? && repo.verification_pending? }
+    end
+
+    def concurrency
+      Integer(@concurrency)
+    end
+
+    def validate!
+      raise ArgumentError, 'schema_version must be 1' unless @schema_version == 1
+
+      begin
+        @concurrency = Integer(@concurrency.to_s, 10)
+      rescue ArgumentError
+        raise ArgumentError, 'concurrency must be an integer at least 1'
+      end
+      raise ArgumentError, 'concurrency must be at least 1' if @concurrency < 1
+
+      repos.each(&:validate!)
+      duplicate_ids = repos.map(&:id).tally.select { |_id, count| count > 1 }.keys
+      raise ArgumentError, "duplicate repo ids: #{duplicate_ids.join(', ')}" if duplicate_ids.any?
+    end
+  end
+
+  class Repo
+    PACKAGE_MANAGERS = %w[npm pnpm yarn yarn_classic yarn_berry].freeze
+    attr_reader :data, :defaults
+
+    def initialize(data, defaults:)
+      @data = data
+      @defaults = defaults
+    end
+
+    def id
+      data.fetch('id') { github.split('/', 2).last }
+    end
+
+    def github
+      data.fetch('github') { data.fetch('name') }
+    end
+
+    def tier
+      data.fetch('tier', defaults.fetch('tier', 'optional'))
+    end
+
+    def enabled?
+      data.fetch('enabled', true) != false
+    end
+
+    def verification_pending?
+      data.fetch('verify', false) == true
+    end
+
+    def package_manager
+      data.fetch('package_manager', defaults.fetch('package_manager', 'pnpm'))
+    end
+
+    def branch_prefix
+      data.fetch('branch_prefix', defaults.fetch('branch_prefix', 'demo-fleet'))
+    end
+
+    def packages
+      raw_packages = data.fetch('packages', [])
+      unless raw_packages.is_a?(Array)
+        raise ArgumentError,
+              "repo #{id} packages must be an array of ecosystem/name entries"
+      end
+
+      raw_packages.map do |package_data|
+        unless package_data.is_a?(Hash)
+          raise ArgumentError, "repo #{id} package entries must include ecosystem and name"
+        end
+
+        PackageRef.new(
+          ecosystem: package_data.fetch('ecosystem'),
+          name: package_data.fetch('name')
+        )
+      end
+    end
+
+    def rubygems
+      packages.select { |package| package.ecosystem == 'gem' }.map(&:name)
+    end
+
+    def npm_packages
+      packages.select { |package| package.ecosystem == 'npm' }.map(&:name)
+    end
+
+    def transitive_only_npm_packages
+      Array(data.fetch('transitive_only_npm_packages', defaults.fetch('transitive_only_npm_packages', []))).map(&:to_s)
+    end
+
+    def review_app
+      return if review_app_disabled?
+
+      raw_review_app = review_app_data
+      raise ArgumentError, "repo #{id} review_app must be a mapping" unless raw_review_app.is_a?(Hash)
+
+      ReviewApp.new(
+        cpflow_app_name: raw_review_app['cpflow_app_name'],
+        cpln_workload_name: raw_review_app['cpln_workload_name'],
+        live_url: raw_review_app['live_url']
+      )
+    end
+
+    def verify_commands
+      if data.key?('verify_commands') || defaults.key?('verify_commands')
+        return validated_verify_commands(data.fetch('verify_commands', defaults['verify_commands']))
+      end
+
+      %w[ruby_test js_test build].filter_map do |key|
+        validated_legacy_verify_command(key, data.fetch(key, defaults[key]))
+      end
+    end
+
+    def verify_template
+      template = data.fetch('verify_template', defaults['verify_template'])
+      template = template.to_s.strip unless template.nil?
+      template == '' ? nil : template
+    end
+
+    def trust_mise?
+      data.fetch('trust_mise', defaults.fetch('trust_mise', false)) == true
+    end
+
+    def smoke_urls
+      Array(data.fetch('smoke_urls') { data.fetch('smoke', defaults.fetch('smoke_urls', [])) })
+    end
+
+    def validate!
+      validate_id!
+      validate_github!
+      validate_package_manager!
+      validate_branch_prefix!
+
+      app = review_app
+      app.validate!(id) if app && !verification_pending?
+      raise ArgumentError, "repo #{id} packages must include rubygems or npm" if rubygems.empty? && npm_packages.empty?
+
+      verify_commands
+
+      invalid_transitive_packages = transitive_only_npm_packages - npm_packages
+      return if invalid_transitive_packages.empty?
+
+      raise ArgumentError,
+            "repo #{id} transitive_only_npm_packages are not declared npm packages: " \
+            "#{invalid_transitive_packages.join(', ')}"
+    end
+
+    private
+
+    def validated_verify_commands(commands)
+      valid = commands.is_a?(Array) && commands.all? do |command|
+        command.is_a?(String) && !command.strip.empty?
+      end
+      return commands if valid
+
+      raise ArgumentError, "repo #{id} verify_commands must be an array of non-empty strings"
+    end
+
+    def validated_legacy_verify_command(key, value)
+      return if value.nil? || (value.is_a?(String) && value.strip.empty?)
+      raise ArgumentError, "repo #{id} #{key} must be a string" unless value.is_a?(String)
+
+      value
+    end
+
+    def review_app_data
+      data.fetch('review_app', defaults.fetch('review_app', {}))
+    end
+
+    def review_app_disabled?
+      source = data.key?('review_app') ? data : defaults
+      source.key?('review_app') && source['review_app'].nil?
+    end
+
+    def validate_id!
+      raise ArgumentError, 'repo id is required' if id.strip.empty?
+      return if id.match?(/\A[\w.-]+\z/) && !%w[. ..].include?(id)
+
+      raise ArgumentError, "repo id #{id.inspect} must be a safe path segment"
+    end
+
+    def validate_github!
+      return if github.match?(%r{\A[\w.-]+/[\w.-]+\z})
+
+      raise ArgumentError, "repo #{id} github must be owner/name"
+    end
+
+    def validate_package_manager!
+      return if PACKAGE_MANAGERS.include?(package_manager)
+
+      raise ArgumentError, "repo #{id} has unsupported package_manager #{package_manager.inspect}"
+    end
+
+    def validate_branch_prefix!
+      segments = branch_prefix.is_a?(String) ? branch_prefix.split('/', -1) : []
+      valid = segments.any? && segments.all? do |segment|
+        segment.match?(/\A\w[\w.-]*\z/) && !segment.include?('..') && !segment.end_with?('.', '.lock')
+      end
+      return if valid
+
+      raise ArgumentError, "repo #{id} branch_prefix #{branch_prefix.inspect} is not a safe git ref prefix"
+    end
+  end
+end

--- a/lib/demo_fleet/manifest.rb
+++ b/lib/demo_fleet/manifest.rb
@@ -137,7 +137,10 @@ module DemoFleet
     end
 
     def id
-      data.fetch('id') { github.split('/', 2).last }
+      return data['id'] if data.key?('id')
+
+      github_value = github
+      github_value.is_a?(String) ? github_value.split('/', 2).last : github_value
     end
 
     def github
@@ -280,6 +283,7 @@ module DemoFleet
     end
 
     def validate_id!
+      raise ArgumentError, 'repo id must be a string' unless id.is_a?(String)
       raise ArgumentError, 'repo id is required' if id.strip.empty?
       return if id.match?(/\A[\w.-]+\z/) && !%w[. ..].include?(id)
 
@@ -287,6 +291,7 @@ module DemoFleet
     end
 
     def validate_github!
+      raise ArgumentError, "repo #{id} github must be a string" unless github.is_a?(String)
       return if github.match?(%r{\A[\w.-]+/[\w.-]+\z})
 
       raise ArgumentError, "repo #{id} github must be owner/name"

--- a/lib/demo_fleet/review_app.rb
+++ b/lib/demo_fleet/review_app.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DemoFleet
+  class ReviewAppLookup
+    def url_for(cpflow_app_name:, branch_name:)
+      raise NotImplementedError, 'CPFlow URL lookup is provided by the executor environment'
+    end
+  end
+end

--- a/lib/demo_fleet/runner.rb
+++ b/lib/demo_fleet/runner.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module DemoFleet
+  Result = Struct.new(:repo_id, :status, :value, :error, keyword_init: true)
+
+  class Runner
+    def initialize(concurrency:, &work)
+      @concurrency = Integer(concurrency)
+      raise ArgumentError, 'concurrency must be at least 1' if @concurrency < 1
+
+      @work = work || proc { |plan| plan }
+    end
+
+    def run(plans)
+      return [] if plans.empty?
+
+      queue = Queue.new
+      plans.each_with_index { |plan, index| queue << [index, plan] }
+      results = Queue.new
+
+      threads = workers(plans.length).map do
+        Thread.new do
+          loop do
+            index, plan = queue.pop(true)
+            results << [index, run_one(plan)]
+          rescue ThreadError
+            break
+          end
+        end
+      end
+      threads.each(&:join)
+
+      Array.new(plans.length) { results.pop }.sort_by(&:first).map(&:last)
+    end
+
+    private
+
+    def workers(plan_count)
+      Array.new([@concurrency, plan_count].min)
+    end
+
+    def run_one(plan)
+      value = @work.call(plan)
+      Result.new(repo_id: plan.repo.id, status: 'success', value: value)
+    rescue StandardError => e
+      Result.new(repo_id: plan.repo.id, status: 'failure', error: e.message)
+    end
+  end
+end

--- a/lib/demo_fleet/supply_chain_policy.rb
+++ b/lib/demo_fleet/supply_chain_policy.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'time'
+require 'yaml'
+
+module DemoFleet
+  class SupplyChainPolicy
+    SECONDS_PER_DAY = 24 * 60 * 60
+    TRACKS = %w[release freshness].freeze
+    ECOSYSTEMS = %w[npm rubygems].freeze
+
+    attr_reader :minimum_age_days, :trusted_targeted_packages, :break_glass_days
+
+    def self.from_file(path)
+      data = YAML.safe_load_file(path, aliases: true) || {}
+      break_glass = data.fetch('break_glass', {}) || {}
+      new(
+        minimum_age_days: data.fetch('minimum_age_days', {}),
+        trusted_targeted_packages: data.fetch('trusted_targeted_packages', {}),
+        break_glass_days: break_glass.fetch('max_age_days', 7)
+      )
+    end
+
+    def self.from_manifest(manifest)
+      age_gate = manifest.defaults.fetch('age_gate')
+      raise ArgumentError, 'defaults.age_gate must be a mapping' unless age_gate.is_a?(Hash)
+
+      own_packages = age_gate.fetch('own_packages', {})
+      raise ArgumentError, 'defaults.age_gate.own_packages must be a mapping' unless own_packages.is_a?(Hash)
+
+      new(
+        minimum_age_days: {
+          'release' => {
+            'npm' => age_gate.fetch('npm_min_days'),
+            'rubygems' => age_gate.fetch('gem_min_days')
+          },
+          'freshness' => {
+            'npm' => age_gate.fetch('npm_min_days'),
+            'rubygems' => age_gate.fetch('gem_min_days')
+          }
+        },
+        trusted_targeted_packages: {
+          'npm' => own_packages.fetch('npm', []),
+          'rubygems' => own_packages.fetch('gem', [])
+        }
+      )
+    end
+
+    def initialize(minimum_age_days:, trusted_targeted_packages:, break_glass_days: 7)
+      @minimum_age_days = stringify_hash(minimum_age_days)
+      @trusted_targeted_packages = stringify_hash(trusted_targeted_packages)
+      @break_glass_days = Integer(break_glass_days)
+    end
+
+    def allows_version?(ecosystem:, package_name:, created_at:, track:, now: Time.now.utc, targeted: false,
+                        break_glass: nil)
+      track = canonical_track(track)
+      ecosystem = canonical_ecosystem(ecosystem)
+
+      return true if track == 'release' && targeted && trusted_package?(ecosystem, package_name)
+      return true if break_glass_allowed?(break_glass, now: now)
+
+      minimum_days = minimum_days_for(track, ecosystem)
+      return true if minimum_days <= 0
+
+      created_at_time = created_at.is_a?(Time) ? created_at : Time.parse(created_at.to_s)
+      (now - created_at_time) >= (minimum_days * SECONDS_PER_DAY)
+    end
+
+    def trusted_package?(ecosystem, package_name)
+      Array(trusted_targeted_packages.fetch(canonical_ecosystem(ecosystem), [])).include?(package_name.to_s)
+    end
+
+    def break_glass_active?(applied_at:, now: Time.now.utc)
+      return false unless applied_at
+
+      applied_at_time = applied_at.is_a?(Time) ? applied_at : Time.parse(applied_at.to_s)
+      age = now - applied_at_time
+      age.between?(0, break_glass_days * SECONDS_PER_DAY)
+    end
+
+    def break_glass_allowed?(break_glass, now:)
+      return false unless break_glass
+
+      break_glass_active?(applied_at: break_glass_value(break_glass, :applied_at), now: now) &&
+        break_glass_value(break_glass, :approved_by).to_s.strip != '' &&
+        break_glass_value(break_glass, :tracking_issue).to_s.strip != ''
+    rescue KeyError
+      false
+    end
+
+    def break_glass_value(metadata, key)
+      metadata.fetch(key) { metadata.fetch(key.to_s) }
+    end
+
+    private
+
+    def minimum_days_for(track, ecosystem)
+      rule = minimum_age_days.fetch(track.to_s, minimum_age_days.fetch('default', 0))
+      rule = rule.fetch(canonical_ecosystem(ecosystem), rule.fetch('default', 0)) if rule.is_a?(Hash)
+      rule.to_i
+    end
+
+    def canonical_track(track)
+      value = track.to_s
+      raise ArgumentError, "unknown release track: #{track.inspect}" unless TRACKS.include?(value)
+
+      value
+    end
+
+    def canonical_ecosystem(ecosystem)
+      value = ecosystem.to_s == 'gem' ? 'rubygems' : ecosystem.to_s
+      raise ArgumentError, "unknown package ecosystem: #{ecosystem.inspect}" unless ECOSYSTEMS.include?(value)
+
+      value
+    end
+
+    def stringify_hash(hash)
+      hash.to_h.transform_keys(&:to_s).transform_values do |value|
+        value.is_a?(Hash) ? stringify_hash(value) : value
+      end
+    end
+  end
+end

--- a/lib/demo_fleet/supply_chain_policy.rb
+++ b/lib/demo_fleet/supply_chain_policy.rb
@@ -19,10 +19,12 @@ module DemoFleet
         trusted_targeted_packages: data.fetch('trusted_targeted_packages', {}),
         break_glass_days: break_glass.fetch('max_age_days', 7)
       )
+    rescue Psych::Exception => e
+      raise ArgumentError, "Unable to parse supply-chain policy from #{path}: #{e.message}"
     end
 
     def self.from_manifest(manifest)
-      age_gate = manifest.defaults.fetch('age_gate')
+      age_gate = required_value(manifest.defaults, 'age_gate', path: 'defaults')
       raise ArgumentError, 'defaults.age_gate must be a mapping' unless age_gate.is_a?(Hash)
 
       own_packages = age_gate.fetch('own_packages', {})
@@ -31,12 +33,12 @@ module DemoFleet
       new(
         minimum_age_days: {
           'release' => {
-            'npm' => age_gate.fetch('npm_min_days'),
-            'rubygems' => age_gate.fetch('gem_min_days')
+            'npm' => required_value(age_gate, 'npm_min_days', path: 'defaults.age_gate'),
+            'rubygems' => required_value(age_gate, 'gem_min_days', path: 'defaults.age_gate')
           },
           'freshness' => {
-            'npm' => age_gate.fetch('npm_min_days'),
-            'rubygems' => age_gate.fetch('gem_min_days')
+            'npm' => required_value(age_gate, 'npm_min_days', path: 'defaults.age_gate'),
+            'rubygems' => required_value(age_gate, 'gem_min_days', path: 'defaults.age_gate')
           }
         },
         trusted_targeted_packages: {
@@ -45,6 +47,13 @@ module DemoFleet
         }
       )
     end
+
+    def self.required_value(mapping, key, path:)
+      return mapping[key] if mapping.key?(key)
+
+      raise ArgumentError, "#{path}.#{key} is required"
+    end
+    private_class_method :required_value
 
     def initialize(minimum_age_days:, trusted_targeted_packages:, break_glass_days: 7)
       @minimum_age_days = stringify_hash(minimum_age_days)

--- a/lib/demo_fleet/update_planner.rb
+++ b/lib/demo_fleet/update_planner.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'shellwords'
+
+module DemoFleet
+  class UpdatePlanner
+    VERSION_APPLIER_PATH = File.expand_path('../../script/demo-fleet-apply-versions', __dir__)
+    IMPLIED_TARGETS = {
+      rubygems: { 'react_on_rails_pro' => 'react_on_rails' },
+      npm: { 'react-on-rails-pro' => 'react-on-rails' }
+    }.freeze
+
+    attr_reader :manifest, :rubygems_versions, :npm_versions, :track, :date, :tier, :repo_id
+
+    def initialize(manifest:, rubygems_versions:, npm_versions:, track:, date: Date.today, tier: nil, repo_id: nil)
+      @manifest = manifest
+      @rubygems_versions = rubygems_versions.transform_keys(&:to_s)
+      @npm_versions = npm_versions.transform_keys(&:to_s)
+      @track = track.to_s
+      @date = date
+      @tier = tier
+      @repo_id = repo_id
+      validate!
+    end
+
+    def plans
+      selected_repos.map { |repo| RepoUpdatePlan.new(repo, self) }.tap do |repo_plans|
+        validate_release_targets!(repo_plans)
+      end
+    end
+
+    def to_markdown
+      lines = [
+        '# Demo Fleet Update Plan',
+        '',
+        "- Track: `#{track}`",
+        "- Date: `#{date.strftime('%Y-%m-%d')}`",
+        "- Repositories: `#{plans.length}`",
+        ''
+      ]
+
+      if plans.empty?
+        lines << 'No verified, enabled repositories matched this run.'
+        return lines.join("\n")
+      end
+
+      lines.push(
+        '| Repo | Tier | Branch |',
+        '| --- | --- | --- |'
+      )
+
+      plans.each do |plan|
+        lines << "| `#{plan.repo.github}` | `#{plan.repo.tier}` | `#{plan.branch_name}` |"
+
+        lines.push('', "## #{plan.repo.github}", '', "- Branch: `#{plan.branch_name}`")
+
+        append_list(lines, 'Dependency commands', plan.dependency_commands)
+        append_list(lines, 'Verification commands', plan.verify_commands)
+        append_list(lines, 'Smoke URLs', plan.smoke_urls)
+      end
+
+      lines.join("\n")
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "Unsupported track #{track.inspect}" unless %w[release freshness].include?(track)
+      return unless track == 'release' && rubygems_versions.empty? && npm_versions.empty?
+
+      raise ArgumentError, 'release track requires at least one --gem or --npm target version'
+    end
+
+    def validate_release_targets!(repo_plans)
+      return unless track == 'release'
+      return if repo_plans.empty?
+
+      validate_repos_receive_targets!(repo_plans)
+      validate_requested_targets_match!(repo_plans)
+    end
+
+    def validate_repos_receive_targets!(repo_plans)
+      unmatched = repo_plans.select { |plan| plan.dependency_commands.empty? }.map { |plan| plan.repo.id }
+      return if unmatched.empty?
+
+      raise ArgumentError, "release target versions do not match packages for: #{unmatched.join(', ')}"
+    end
+
+    def validate_requested_targets_match!(repo_plans)
+      return if repo_id || tier
+
+      selected_gems = targetable_packages(repo_plans, :rubygems)
+      selected_npm = targetable_packages(repo_plans, :npm)
+      unmatched_gems = rubygems_versions.keys - selected_gems
+      unmatched_npm = npm_versions.keys - selected_npm
+      unmatched_targets = unmatched_gems.map { |name| "gem:#{name}" } + unmatched_npm.map { |name| "npm:#{name}" }
+      return if unmatched_targets.empty?
+
+      raise ArgumentError, "release targets match no selected repo: #{unmatched_targets.join(', ')}"
+    end
+
+    def targetable_packages(repo_plans, ecosystem)
+      packages = repo_plans.flat_map do |plan|
+        ecosystem == :rubygems ? plan.repo.rubygems : plan.repo.npm_packages
+      end.uniq
+      UpdatePlanner::IMPLIED_TARGETS.fetch(ecosystem).each do |direct_package, implied_package|
+        packages << implied_package if packages.include?(direct_package)
+      end
+      packages.uniq
+    end
+
+    def selected_repos
+      repos = manifest.enabled_repos
+      repos = repos.select { |repo| repo.tier == tier } if tier
+      repos = repos.select { |repo| repo.id == repo_id } if repo_id
+      repos
+    end
+
+    def append_list(lines, title, values)
+      return if values.empty?
+
+      lines.push('', "#{title}:")
+      values.each { |value| lines << "- `#{value}`" }
+    end
+  end
+
+  class RepoUpdatePlan
+    attr_reader :repo, :planner
+
+    def initialize(repo, planner)
+      @repo = repo
+      @planner = planner
+    end
+
+    def branch_name
+      "#{repo.branch_prefix}/#{planner.track}-#{planner.date.strftime('%Y%m%d')}-#{repo.id}"
+    end
+
+    def dependency_commands
+      targeted_commands = targeted_dependency_commands
+      return targeted_commands if targeted_commands.any?
+
+      rubygems_commands + npm_commands
+    end
+
+    def verify_commands
+      repo.verify_commands
+    end
+
+    def smoke_urls
+      repo.smoke_urls
+    end
+
+    private
+
+    def rubygems_commands
+      return ['bundle update'] if planner.track == 'freshness' && planner.rubygems_versions.empty? && repo.rubygems.any?
+
+      []
+    end
+
+    def npm_commands
+      if planner.track == 'freshness' && planner.npm_versions.empty? && repo.npm_packages.any?
+        return freshness_npm_commands
+      end
+
+      []
+    end
+
+    def targeted_dependency_commands
+      gem_targets = targeted_versions(repo.rubygems, planner.rubygems_versions, ecosystem: :rubygems)
+      npm_targets = targeted_versions(repo.npm_packages, planner.npm_versions, ecosystem: :npm)
+      return [] if gem_targets.empty? && npm_targets.empty?
+
+      [
+        version_applier_command(gem_targets, npm_targets),
+        bundle_update_command(gem_targets),
+        package_install_command(npm_targets)
+      ].compact
+    end
+
+    def targeted_versions(package_names, versions, ecosystem:)
+      targetable_names = package_names.dup
+      UpdatePlanner::IMPLIED_TARGETS.fetch(ecosystem).each do |direct_package, implied_package|
+        targetable_names << implied_package if package_names.include?(direct_package)
+      end
+
+      targetable_names.uniq.filter_map do |package_name|
+        version = versions[package_name]
+        [package_name, version] if version
+      end
+    end
+
+    def version_applier_command(gem_targets, npm_targets)
+      argv = ['ruby', UpdatePlanner::VERSION_APPLIER_PATH]
+      gem_targets.each { |name, version| argv.push('--gem', "#{name}=#{version}") }
+      npm_targets.each { |name, version| argv.push('--npm', "#{name}=#{version}") }
+      transitive_targets = npm_targets.map(&:first) & repo.transitive_only_npm_packages
+      transitive_targets.each { |name| argv.push('--allow-missing-npm-target', name) }
+      argv.shelljoin
+    end
+
+    def bundle_update_command(gem_targets)
+      return nil if gem_targets.empty?
+
+      ['bundle', 'update', *gem_targets.map(&:first)].shelljoin
+    end
+
+    def package_install_command(npm_targets)
+      return nil if npm_targets.empty?
+
+      executable = case repo.package_manager
+                   when 'pnpm' then 'pnpm'
+                   when 'yarn', 'yarn_classic', 'yarn_berry' then 'yarn'
+                   when 'npm' then 'npm'
+                   else
+                     raise ArgumentError, "Unsupported package manager #{repo.package_manager.inspect} for #{repo.id}"
+                   end
+      install_changed_package_manifests_command(executable)
+    end
+
+    def install_changed_package_manifests_command(executable)
+      script = "git diff --name-only -z -- package.json ':(glob)**/package.json' | " \
+               "while IFS= read -r -d '' manifest; do " \
+               'directory="${manifest%/package.json}"; ' \
+               '[[ "$directory" == "$manifest" ]] && directory=.; ' \
+               "(cd \"$directory\" && #{executable} install); " \
+               'done'
+      "bash -lc #{script.inspect}"
+    end
+
+    def freshness_npm_commands
+      case repo.package_manager
+      when 'pnpm'
+        ['pnpm update --latest']
+      when 'yarn', 'yarn_classic'
+        ['yarn upgrade --latest']
+      when 'yarn_berry'
+        ["yarn up '*'"]
+      when 'npm'
+        ['npx --yes npm-check-updates@19.1.1 --upgrade', 'npm install']
+      else
+        raise ArgumentError, "Unsupported package manager #{repo.package_manager.inspect} for #{repo.id}"
+      end
+    end
+  end
+end

--- a/lib/demo_fleet/update_planner.rb
+++ b/lib/demo_fleet/update_planner.rb
@@ -25,7 +25,7 @@ module DemoFleet
     end
 
     def plans
-      selected_repos.map { |repo| RepoUpdatePlan.new(repo, self) }.tap do |repo_plans|
+      @plans ||= selected_repos.map { |repo| RepoUpdatePlan.new(repo, self) }.tap do |repo_plans|
         validate_release_targets!(repo_plans)
       end
     end
@@ -76,8 +76,36 @@ module DemoFleet
       return unless track == 'release'
       return if repo_plans.empty?
 
+      validate_implied_targets_complete!(repo_plans)
       validate_repos_receive_targets!(repo_plans)
-      validate_requested_targets_match!(repo_plans)
+      validate_requested_targets_match!
+    end
+
+    def validate_implied_targets_complete!(repo_plans)
+      incomplete = repo_plans.flat_map do |plan|
+        [
+          incomplete_implied_targets(plan.repo, :rubygems, rubygems_versions),
+          incomplete_implied_targets(plan.repo, :npm, npm_versions)
+        ].flatten
+      end
+      return if incomplete.empty?
+
+      raise ArgumentError, "base targets for Pro-only repos require matching Pro versions: #{incomplete.join(', ')}"
+    end
+
+    def incomplete_implied_targets(repo, ecosystem, versions)
+      package_names = ecosystem == :rubygems ? repo.rubygems : repo.npm_packages
+      direct_package_names = if ecosystem == :npm
+                               package_names - repo.transitive_only_npm_packages
+                             else
+                               package_names
+                             end
+      IMPLIED_TARGETS.fetch(ecosystem).filter_map do |direct_package, implied_package|
+        pro_only = direct_package_names.include?(direct_package) && !direct_package_names.include?(implied_package)
+        next unless pro_only && versions.key?(implied_package) && !versions.key?(direct_package)
+
+        "#{repo.id} requires #{ecosystem}:#{direct_package} with #{ecosystem}:#{implied_package}"
+      end
     end
 
     def validate_repos_receive_targets!(repo_plans)
@@ -87,17 +115,16 @@ module DemoFleet
       raise ArgumentError, "release target versions do not match packages for: #{unmatched.join(', ')}"
     end
 
-    def validate_requested_targets_match!(repo_plans)
-      return if repo_id || tier
-
-      selected_gems = targetable_packages(repo_plans, :rubygems)
-      selected_npm = targetable_packages(repo_plans, :npm)
-      unmatched_gems = rubygems_versions.keys - selected_gems
-      unmatched_npm = npm_versions.keys - selected_npm
+    def validate_requested_targets_match!
+      fleet_plans = manifest.enabled_repos.map { |repo| RepoUpdatePlan.new(repo, self) }
+      fleet_gems = targetable_packages(fleet_plans, :rubygems)
+      fleet_npm = targetable_packages(fleet_plans, :npm)
+      unmatched_gems = rubygems_versions.keys - fleet_gems
+      unmatched_npm = npm_versions.keys - fleet_npm
       unmatched_targets = unmatched_gems.map { |name| "gem:#{name}" } + unmatched_npm.map { |name| "npm:#{name}" }
       return if unmatched_targets.empty?
 
-      raise ArgumentError, "release targets match no selected repo: #{unmatched_targets.join(', ')}"
+      raise ArgumentError, "release targets match no verified fleet repo: #{unmatched_targets.join(', ')}"
     end
 
     def targetable_packages(repo_plans, ecosystem)
@@ -183,7 +210,7 @@ module DemoFleet
     def targeted_versions(package_names, versions, ecosystem:)
       targetable_names = package_names.dup
       UpdatePlanner::IMPLIED_TARGETS.fetch(ecosystem).each do |direct_package, implied_package|
-        targetable_names << implied_package if package_names.include?(direct_package)
+        targetable_names << implied_package if package_names.include?(direct_package) && versions.key?(direct_package)
       end
 
       targetable_names.uniq.filter_map do |package_name|

--- a/script/demo-fleet
+++ b/script/demo-fleet
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+
+require 'demo_fleet'
+
+exit DemoFleet::CLI.run(ARGV)

--- a/script/demo-fleet-apply-versions
+++ b/script/demo-fleet-apply-versions
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require_relative '../lib/demo_fleet/dependency_file_updater'
+
+options = {
+  root: Dir.pwd,
+  rubygems_versions: {},
+  npm_versions: {},
+  allowed_missing_npm_targets: []
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = 'Usage: script/demo-fleet-apply-versions [options]'
+  opts.on('--root PATH', 'Repository root; defaults to current directory') { |value| options[:root] = value }
+  opts.on('--gem NAME=VERSION', 'Set an existing Gemfile gem version; repeatable') do |value|
+    name, version = value.split('=', 2)
+    raise OptionParser::InvalidArgument, 'Expected NAME=VERSION' if name.to_s.empty? || version.to_s.empty?
+
+    options[:rubygems_versions][name] = version
+  end
+  opts.on('--npm NAME=VERSION', 'Set an existing package.json version; repeatable') do |value|
+    name, version = value.split('=', 2)
+    raise OptionParser::InvalidArgument, 'Expected NAME=VERSION' if name.to_s.empty? || version.to_s.empty?
+
+    options[:npm_versions][name] = version
+  end
+  opts.on('--allow-missing-npm-target NAME', 'Allow one explicitly transitive-only npm package; repeatable') do |name|
+    options[:allowed_missing_npm_targets] << name
+  end
+end
+
+parser.parse!(ARGV)
+
+DemoFleet::DependencyFileUpdater.new(
+  root: options[:root],
+  rubygems_versions: options[:rubygems_versions],
+  npm_versions: options[:npm_versions],
+  allowed_missing_npm_targets: options[:allowed_missing_npm_targets]
+).apply

--- a/templates/demo-repo/.github/workflows/dependency-review.yml
+++ b/templates/demo-repo/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate

--- a/templates/demo-repo/dependabot.yml
+++ b/templates/demo-repo/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/templates/demo-repo/marketplace-rsc/script/demo-fleet-verify
+++ b/templates/demo-repo/marketplace-rsc/script/demo-fleet-verify
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle exec rake
+pnpm lint:rsc
+bundle exec rake react_on_rails:generate_packs
+RAILS_ENV=production NODE_ENV=production SECRET_KEY_BASE=dummy_secret_key_base_for_demo_fleet pnpm build:production
+pnpm verify:rsc
+git diff --exit-code -- app/javascript/packs

--- a/templates/demo-repo/pnpm-workspace.yaml
+++ b/templates/demo-repo/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
+minimumReleaseAgeExclude:
+  - react-on-rails
+  - react-on-rails-pro
+  - react-on-rails-pro-node-renderer
+  - react-on-rails-rsc
+  - shakapacker
+  - shakapacker-rspack
+
+allowBuilds: {}

--- a/templates/demo-repo/script/demo-fleet-verify
+++ b/templates/demo-repo/script/demo-fleet-verify
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -x bin/ci ]]; then
+  bin/ci
+elif [[ -x bin/test ]]; then
+  bin/test
+else
+  bundle exec rake
+fi

--- a/test/demo_fleet_test.rb
+++ b/test/demo_fleet_test.rb
@@ -287,6 +287,25 @@ class DemoFleetTest < Minitest::Test
     assert_includes error.message, 'safe path segment'
   end
 
+  def test_manifest_rejects_non_string_repo_ids_with_schema_errors
+    [123, nil].each do |repo_id|
+      data = {
+        'schema_version' => 1,
+        'repos' => [
+          {
+            'id' => repo_id,
+            'github' => 'shakacode/demo',
+            'packages' => [{ 'ecosystem' => 'gem', 'name' => 'react_on_rails' }]
+          }
+        ]
+      }
+
+      error = assert_raises(ArgumentError) { DemoFleet::Manifest.new(data) }
+
+      assert_equal 'repo id must be a string', error.message
+    end
+  end
+
   def test_manifest_rejects_unsupported_package_manager
     path = write_yaml(<<~YAML)
       schema_version: 1
@@ -471,6 +490,53 @@ class DemoFleetTest < Minitest::Test
     gemfile = File.read(File.join(dir, 'Gemfile'))
     assert_includes gemfile, "  gem 'react_on_rails', '17.0.0.rc.10'"
     assert_includes gemfile, "  gem 'shakapacker', '10.3.0'"
+  end
+
+  def test_dependency_file_updater_preserves_options_after_a_nested_multiline_source
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'Gemfile'), <<~RUBY)
+      source 'https://rubygems.org'
+
+      gem 'react_on_rails',
+        git: {
+          remote: 'https://github.com/shakacode/react_on_rails.git',
+          branch: 'main'
+        },
+        require: false
+    RUBY
+
+    DemoFleet::DependencyFileUpdater.new(
+      root: dir,
+      rubygems_versions: { 'react_on_rails' => '17.0.0.rc.10' },
+      npm_versions: {}
+    ).apply
+
+    gemfile = File.read(File.join(dir, 'Gemfile'))
+    assert_includes gemfile, "gem 'react_on_rails', '17.0.0.rc.10', require: false"
+    refute_includes gemfile, 'github.com/shakacode/react_on_rails'
+    refute_nil Ripper.sexp(gemfile)
+  end
+
+  def test_dependency_file_updater_handles_inline_comments_in_multiline_sources
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'Gemfile'), <<~RUBY)
+      source 'https://rubygems.org'
+
+      gem 'react_on_rails', git: 'https://github.com/shakacode/react_on_rails.git', # pinned
+        branch: 'main',
+        require: false
+    RUBY
+
+    DemoFleet::DependencyFileUpdater.new(
+      root: dir,
+      rubygems_versions: { 'react_on_rails' => '17.0.0.rc.10' },
+      npm_versions: {}
+    ).apply
+
+    gemfile = File.read(File.join(dir, 'Gemfile'))
+    assert_includes gemfile, "gem 'react_on_rails', '17.0.0.rc.10', require: false"
+    refute_includes gemfile, 'branch:'
+    refute_nil Ripper.sexp(gemfile)
   end
 
   def test_dependency_file_updater_updates_nested_package_manifests_and_allows_transitive_targets
@@ -680,6 +746,13 @@ class DemoFleetTest < Minitest::Test
           packages:
             - ecosystem: gem
               name: react_on_rails
+        - id: pro-rsc-demo
+          github: shakacode/pro-rsc-demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails_pro
+            - ecosystem: npm
+              name: react-on-rails-rsc
     YAML
 
     planner = DemoFleet::UpdatePlanner.new(
@@ -695,6 +768,32 @@ class DemoFleetTest < Minitest::Test
 
     planned_repo_ids = planner.plans.map { |plan| plan.repo.id }
     assert_equal ['non-pro-demo'], planned_repo_ids
+  end
+
+  def test_repo_filtered_update_plan_rejects_targets_unknown_to_the_verified_fleet
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: demo
+          github: shakacode/demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {
+        'react_on_rails' => '17.0.0.rc.10',
+        'react_on_rails_typo' => '17.0.0.rc.10'
+      },
+      npm_versions: {},
+      track: 'release',
+      repo_id: 'demo'
+    )
+
+    error = assert_raises(ArgumentError) { planner.plans }
+    assert_includes error.message, 'gem:react_on_rails_typo'
   end
 
   def test_update_plan_targets_base_packages_implied_by_direct_pro_packages
@@ -728,6 +827,69 @@ class DemoFleetTest < Minitest::Test
     assert_includes command, '--gem react_on_rails_pro\\=17.0.0.rc.10'
     assert_includes command, '--npm react-on-rails\\=17.0.0-rc.10'
     assert_includes command, '--npm react-on-rails-pro\\=17.0.0-rc.10'
+  end
+
+  def test_update_plan_rejects_base_only_versions_for_pro_only_repos
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: pro-only-demo
+          github: shakacode/pro-only-demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails_pro
+            - ecosystem: gem
+              name: shakapacker
+            - ecosystem: npm
+              name: react-on-rails-pro
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {
+        'react_on_rails' => '17.0.0.rc.10',
+        'shakapacker' => '10.0.0'
+      },
+      npm_versions: { 'react-on-rails' => '17.0.0-rc.10' },
+      track: 'release'
+    )
+
+    error = assert_raises(ArgumentError) { planner.plans }
+
+    assert_includes error.message, 'rubygems:react_on_rails_pro'
+    assert_includes error.message, 'npm:react-on-rails-pro'
+  end
+
+  def test_update_plan_treats_transitive_only_base_packages_as_pro_only
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: pro-rsc-demo
+          github: shakacode/pro-rsc-demo
+          packages:
+            - ecosystem: npm
+              name: react-on-rails
+            - ecosystem: npm
+              name: react-on-rails-pro
+            - ecosystem: npm
+              name: react-on-rails-rsc
+          transitive_only_npm_packages:
+            - react-on-rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {},
+      npm_versions: {
+        'react-on-rails' => '17.0.0-rc.10',
+        'react-on-rails-rsc' => '19.2.1-rc.1'
+      },
+      track: 'release'
+    )
+
+    error = assert_raises(ArgumentError) { planner.plans }
+
+    assert_includes error.message, 'npm:react-on-rails-pro'
   end
 
   def test_update_plan_rejects_requested_targets_that_match_no_selected_repo
@@ -898,6 +1060,30 @@ class DemoFleetTest < Minitest::Test
     error = assert_raises(ArgumentError) { DemoFleet::SupplyChainPolicy.from_manifest(manifest) }
 
     assert_equal 'defaults.age_gate must be a mapping', error.message
+  end
+
+  def test_manifest_policy_reports_missing_age_gate_fields
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        age_gate:
+          gem_min_days: 7
+      repos: []
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::SupplyChainPolicy.from_manifest(manifest) }
+
+    assert_equal 'defaults.age_gate.npm_min_days is required', error.message
+  end
+
+  def test_supply_chain_policy_reports_malformed_yaml
+    dir = Dir.mktmpdir
+    path = File.join(dir, 'policy.yml')
+    File.write(path, "minimum_age_days: [\n")
+
+    error = assert_raises(ArgumentError) { DemoFleet::SupplyChainPolicy.from_file(path) }
+
+    assert_includes error.message, "Unable to parse supply-chain policy from #{path}"
   end
 
   def test_break_glass_override_expires_after_policy_window
@@ -1189,9 +1375,10 @@ class DemoFleetTest < Minitest::Test
     end
   end
 
-  def test_executor_resets_a_stale_local_branch_after_its_remote_was_deleted
+  def test_executor_preserves_unique_local_commits_after_its_remote_branch_was_deleted
     Dir.mktmpdir do |workspace|
       _remote, seed, checkout, branch = create_pushed_update_branch(workspace)
+      local_revision = git_revision(checkout, branch)
 
       system('git', '-C', seed, 'checkout', '--quiet', 'main')
       File.write(File.join(seed, 'README.md'), "new main\n")
@@ -1203,8 +1390,9 @@ class DemoFleetTest < Minitest::Test
       command = checkout_branch_command_for(checkout, branch)
       _stdout, stderr, status = Open3.capture3(*command.argv, chdir: checkout)
 
-      assert status.success?, stderr
-      assert_equal git_revision(checkout, 'origin/HEAD'), git_revision(checkout, 'HEAD')
+      refute status.success?
+      assert_includes stderr, 'remote update branch was deleted but local branch contains commits'
+      assert_equal local_revision, git_revision(checkout, 'HEAD')
     end
   end
 

--- a/test/demo_fleet_test.rb
+++ b/test/demo_fleet_test.rb
@@ -1,0 +1,1812 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'fileutils'
+require 'json'
+require 'stringio'
+require 'tmpdir'
+require 'minitest/autorun'
+
+require_relative '../lib/demo_fleet'
+
+class DemoFleetTest < Minitest::Test
+  REMOTE_PHASES = %i[push open_pr].freeze
+
+  class RecordingShell
+    attr_reader :commands
+
+    def initialize(staged_changes:, branch_has_commits:, branch_has_release_commits: branch_has_commits)
+      @staged_changes = staged_changes
+      @branch_has_commits = branch_has_commits
+      @branch_has_release_commits = branch_has_release_commits
+      @commands = []
+    end
+
+    def call(command)
+      commands << command
+    end
+
+    def staged_changes?(_cwd)
+      @staged_changes
+    end
+
+    def branch_has_commits?(_cwd)
+      @branch_has_commits
+    end
+
+    def branch_has_release_commits?(_cwd)
+      @branch_has_release_commits
+    end
+  end
+
+  def test_manifest_loads_defaults_and_filters_enabled_repos
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      defaults:
+        owner: shakacode
+        package_manager: pnpm
+        branch_prefix: demo-fleet
+        verify_commands:
+          - bin/ci
+      repos:
+        - id: marketplace-rsc
+          github: shakacode/react-on-rails-demo-marketplace-rsc
+          tier: hard_gate
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: gem
+              name: shakapacker
+            - ecosystem: npm
+              name: react-on-rails
+          smoke_urls:
+            - /
+            - /products
+        - id: old-demo
+          github: shakacode/react-on-rails-demo
+          enabled: false
+          tier: legacy
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+        - id: draft-demo
+          github: shakacode/draft-demo
+          verify: true
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+
+    manifest = DemoFleet::Manifest.from_file(path)
+
+    assert_equal 3, manifest.repos.length
+    assert_equal ['marketplace-rsc'], manifest.enabled_repos.map(&:id)
+    assert_equal ['draft-demo'], manifest.pending_verification_repos.map(&:id)
+    assert_equal 'pnpm', manifest.enabled_repos.first.package_manager
+    assert_equal ['bin/ci'], manifest.enabled_repos.first.verify_commands
+  end
+
+  def test_manifest_requires_structured_package_refs
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      defaults:
+        package_manager: pnpm
+      repos:
+        - id: marketplace-rsc
+          github: shakacode/react-on-rails-demo-marketplace-rsc
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: npm
+              name: react-on-rails
+          review_app:
+            cpflow_app_name: demo-marketplace-rsc
+            cpln_workload_name: rails
+            live_url: https://rsc.reactonrails.com
+          trust_mise: true
+          verify_template: templates/demo-repo/marketplace-rsc/script/demo-fleet-verify
+    YAML
+
+    manifest = DemoFleet::Manifest.from_file(path)
+    repo = manifest.enabled_repos.first
+
+    assert_equal ['react_on_rails'], repo.rubygems
+    assert_equal ['react-on-rails'], repo.npm_packages
+    assert_equal 'demo-marketplace-rsc', repo.review_app.cpflow_app_name
+    assert_equal 'rails', repo.review_app.cpln_workload_name
+    assert_equal 'https://rsc.reactonrails.com', repo.review_app.live_url
+    assert repo.trust_mise?
+    assert_equal 'templates/demo-repo/marketplace-rsc/script/demo-fleet-verify', repo.verify_template
+  end
+
+  def test_manifest_reads_canonical_react_on_rails_schema
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      concurrency: 8
+      defaults:
+        package_manager: pnpm
+        branch_prefix: chore/demo-fleet
+        ruby_test: bundle exec rspec
+        build: bin/shakapacker
+        age_gate:
+          npm_min_days: 7
+          gem_min_days: 5
+          own_packages:
+            npm: [react-on-rails]
+            gem: [react_on_rails]
+      repos:
+        - name: shakacode/react-on-rails-demo-hacker-news-rsc
+          tier: hard_gate
+          packages:
+            - { ecosystem: gem, name: react_on_rails }
+            - { ecosystem: npm, name: react-on-rails }
+          package_manager: yarn_berry
+          ruby_test: bin/rails test
+          smoke: [/, /news/1]
+    YAML
+
+    manifest = DemoFleet::Manifest.from_source(path)
+    repo = manifest.repos.first
+
+    assert_equal 8, manifest.concurrency
+    assert_equal 'react-on-rails-demo-hacker-news-rsc', repo.id
+    assert_equal 'shakacode/react-on-rails-demo-hacker-news-rsc', repo.github
+    assert_equal 'yarn_berry', repo.package_manager
+    assert_equal ['bin/rails test', 'bin/shakapacker'], repo.verify_commands
+    assert_equal ['/', '/news/1'], repo.smoke_urls
+
+    policy = DemoFleet::SupplyChainPolicy.from_manifest(manifest)
+    assert policy.trusted_package?('npm', 'react-on-rails')
+    refute policy.allows_version?(
+      ecosystem: 'rubygems',
+      package_name: 'rails',
+      created_at: Time.utc(2026, 7, 10),
+      track: 'freshness',
+      now: Time.utc(2026, 7, 14)
+    )
+  end
+
+  def test_manifest_rejects_concurrency_below_one
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      concurrency: 0
+      repos: []
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::Manifest.from_file(path) }
+
+    assert_includes error.message, 'concurrency must be at least 1'
+  end
+
+  def test_manifest_rejects_non_integer_concurrency
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      concurrency: several
+      repos: []
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::Manifest.from_file(path) }
+
+    assert_includes error.message, 'concurrency must be an integer at least 1'
+  end
+
+  def test_manifest_requires_cpflow_app_name_when_repo_is_actionable
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      repos:
+        - id: bad-demo
+          github: shakacode/bad-demo
+          review_app:
+            cpflow_app_name:
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::Manifest.from_file(path) }
+
+    assert_includes error.message, 'cpflow_app_name'
+  end
+
+  def test_manifest_requires_review_app_metadata_when_repo_is_actionable
+    path = write_yaml(<<~YAML, with_default_review_app: false)
+      schema_version: 1
+      repos:
+        - id: bad-demo
+          github: shakacode/bad-demo
+          packages:
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::Manifest.from_file(path) }
+
+    assert_includes error.message, 'cpflow_app_name'
+  end
+
+  def test_manifest_allows_placeholder_review_app_while_repo_verification_is_pending
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      repos:
+        - id: draft-demo
+          github: shakacode/draft-demo
+          verify: true
+          packages:
+            - ecosystem: npm
+              name: react-on-rails
+          review_app:
+            cpflow_app_name:
+    YAML
+
+    manifest = DemoFleet::Manifest.from_file(path)
+
+    assert_empty manifest.enabled_repos
+    assert_equal ['draft-demo'], manifest.pending_verification_repos.map(&:id)
+  end
+
+  def test_manifest_allows_actionable_repo_to_explicitly_disable_review_app
+    path = write_yaml(<<~YAML, with_default_review_app: false)
+      schema_version: 1
+      repos:
+        - id: no-review-app-demo
+          github: shakacode/no-review-app-demo
+          review_app:
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+
+    manifest = DemoFleet::Manifest.from_file(path)
+
+    assert_nil manifest.enabled_repos.first.review_app
+  end
+
+  def test_manifest_rejects_non_array_repos_with_schema_error
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      repos:
+        demo:
+          github: shakacode/demo
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::Manifest.from_file(path) }
+
+    assert_equal 'repos must be an array', error.message
+  end
+
+  def test_manifest_rejects_repo_ids_that_escape_the_workspace
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      repos:
+        - id: ../escape
+          github: shakacode/demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::Manifest.from_file(path) }
+
+    assert_includes error.message, 'safe path segment'
+  end
+
+  def test_manifest_rejects_unsupported_package_manager
+    path = write_yaml(<<~YAML)
+      schema_version: 1
+      repos:
+        - id: demo
+          github: shakacode/demo
+          package_manager: yarn_typo
+          packages:
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::Manifest.from_file(path) }
+
+    assert_includes error.message, 'unsupported package_manager'
+  end
+
+  def test_manifest_rejects_non_string_verification_commands
+    error = assert_raises(ArgumentError) do
+      DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+        schema_version: 1
+        repos:
+          - id: demo
+            github: shakacode/demo
+            verify_commands: [bundle exec rspec, 2]
+            packages:
+              - ecosystem: gem
+                name: react_on_rails
+      YAML
+    end
+
+    assert_equal 'repo demo verify_commands must be an array of non-empty strings', error.message
+  end
+
+  def test_manifest_rejects_an_unsafe_branch_prefix
+    ['bad prefix', '.hidden', 'bad..prefix', 'bad.'].each do |prefix|
+      error = assert_raises(ArgumentError) do
+        DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+          schema_version: 1
+          repos:
+            - id: demo
+              github: shakacode/demo
+              branch_prefix: #{prefix}
+              packages:
+                - ecosystem: gem
+                  name: react_on_rails
+        YAML
+      end
+
+      assert_includes error.message, 'is not a safe git ref prefix'
+    end
+  end
+
+  def test_update_plan_renders_commands_for_target_versions
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        package_manager: pnpm
+        branch_prefix: demo-fleet
+      repos:
+        - id: marketplace-rsc
+          github: shakacode/react-on-rails-demo-marketplace-rsc
+          tier: hard_gate
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: gem
+              name: shakapacker
+            - ecosystem: gem
+              name: cpflow
+            - ecosystem: npm
+              name: react-on-rails
+          verify_commands:
+            - bin/ci
+          smoke_urls:
+            - /
+            - /products
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {
+        'react_on_rails' => '16.7.0',
+        'shakapacker' => '9.6.1'
+      },
+      npm_versions: {
+        'react-on-rails' => '16.7.0'
+      },
+      track: 'release',
+      date: Date.new(2026, 5, 27)
+    )
+
+    markdown = planner.to_markdown
+
+    assert_includes markdown, 'shakacode/react-on-rails-demo-marketplace-rsc'
+    assert_includes markdown, 'demo-fleet/release-20260527-marketplace-rsc'
+    assert_includes markdown, 'demo-fleet-apply-versions'
+    assert_includes markdown, '--gem react_on_rails\\=16.7.0'
+    assert_includes markdown, '--gem shakapacker\\=9.6.1'
+    assert_includes markdown, '--npm react-on-rails\\=16.7.0'
+    assert_includes markdown, 'bundle update react_on_rails shakapacker'
+    assert_includes markdown, 'pnpm install'
+    assert_includes markdown, 'bin/ci'
+    assert_includes markdown, '/products'
+  end
+
+  def test_dependency_file_updater_replaces_source_refs_and_package_overrides
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'Gemfile'), <<~RUBY)
+      source 'https://rubygems.org'
+
+      gem 'react_on_rails', git: 'https://github.com/shakacode/react_on_rails.git',
+                             branch: 'main',
+                             glob: 'react_on_rails/*.gemspec'
+      gem 'react_on_rails_pro', git: 'https://github.com/shakacode/react_on_rails.git',
+                                 branch: 'main',
+                                 glob: 'react_on_rails_pro/*.gemspec'
+      gem 'shakapacker', '~> 9.5'
+      gem 'cpflow', '5.2.0', require: false
+    RUBY
+    package_json = {
+      'dependencies' => {
+        'react-on-rails-pro' => 'github:shakacode/react-on-rails-builds#abc&path:react-on-rails-pro',
+        'react-on-rails-rsc' => 'file:.yalc/react-on-rails-rsc'
+      },
+      'devDependencies' => { 'shakapacker' => '^9.5' },
+      'pnpm' => {
+        'overrides' => {
+          'react-on-rails' => 'github:shakacode/react-on-rails-builds#abc&path:react-on-rails',
+          'shakapacker' => '9.5.0'
+        }
+      }
+    }
+    File.write(File.join(dir, 'package.json'), JSON.pretty_generate(package_json))
+
+    DemoFleet::DependencyFileUpdater.new(
+      root: dir,
+      rubygems_versions: {
+        'react_on_rails' => '17.0.0.rc.0',
+        'react_on_rails_pro' => '17.0.0.rc.0',
+        'shakapacker' => '10.1.0',
+        'cpflow' => '5.3.0'
+      },
+      npm_versions: {
+        'react-on-rails' => '17.0.0-rc.0',
+        'react-on-rails-pro' => '17.0.0-rc.0',
+        'react-on-rails-rsc' => '19.0.5-rc.3',
+        'shakapacker' => '10.1.0'
+      }
+    ).apply
+
+    gemfile = File.read(File.join(dir, 'Gemfile'))
+    assert_includes gemfile, "gem 'react_on_rails', '17.0.0.rc.0'"
+    assert_includes gemfile, "gem 'react_on_rails_pro', '17.0.0.rc.0'"
+    assert_includes gemfile, "gem 'shakapacker', '10.1.0'"
+    assert_includes gemfile, "gem 'cpflow', '5.3.0', require: false"
+    refute_includes gemfile, 'github.com/shakacode/react_on_rails'
+
+    package_json = JSON.parse(File.read(File.join(dir, 'package.json')))
+    assert_equal '17.0.0-rc.0', package_json['dependencies']['react-on-rails-pro']
+    assert_equal '19.0.5-rc.3', package_json['dependencies']['react-on-rails-rsc']
+    assert_equal '10.1.0', package_json['devDependencies']['shakapacker']
+    assert_equal '17.0.0-rc.0', package_json['pnpm']['overrides']['react-on-rails']
+    assert_equal '10.1.0', package_json['pnpm']['overrides']['shakapacker']
+  end
+
+  def test_dependency_file_updater_does_not_consume_the_next_indented_gem_declaration
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'Gemfile'), <<~RUBY)
+      source 'https://rubygems.org'
+
+        gem 'react_on_rails',
+        gem 'shakapacker', '10.3.0'
+    RUBY
+
+    DemoFleet::DependencyFileUpdater.new(
+      root: dir,
+      rubygems_versions: { 'react_on_rails' => '17.0.0.rc.10' },
+      npm_versions: {}
+    ).apply
+
+    gemfile = File.read(File.join(dir, 'Gemfile'))
+    assert_includes gemfile, "  gem 'react_on_rails', '17.0.0.rc.10'"
+    assert_includes gemfile, "  gem 'shakapacker', '10.3.0'"
+  end
+
+  def test_dependency_file_updater_updates_nested_package_manifests_and_allows_transitive_targets
+    dir = Dir.mktmpdir
+    FileUtils.mkdir_p(File.join(dir, 'client'))
+    root_package = { 'dependencies' => { 'react-on-rails-pro-node-renderer' => '17.0.0-rc.9' } }
+    client_package = { 'dependencies' => { 'react-on-rails-pro' => '17.0.0-rc.9' } }
+    File.write(File.join(dir, 'package.json'), JSON.pretty_generate(root_package))
+    File.write(File.join(dir, 'client', 'package.json'), JSON.pretty_generate(client_package))
+
+    DemoFleet::DependencyFileUpdater.new(
+      root: dir,
+      rubygems_versions: {},
+      npm_versions: {
+        'react-on-rails' => '17.0.0-rc.10',
+        'react-on-rails-pro' => '17.0.0-rc.10',
+        'react-on-rails-pro-node-renderer' => '17.0.0-rc.10'
+      },
+      allowed_missing_npm_targets: ['react-on-rails']
+    ).apply
+
+    root_package = JSON.parse(File.read(File.join(dir, 'package.json')))
+    client_package = JSON.parse(File.read(File.join(dir, 'client', 'package.json')))
+    assert_equal '17.0.0-rc.10', root_package['dependencies']['react-on-rails-pro-node-renderer']
+    assert_equal '17.0.0-rc.10', client_package['dependencies']['react-on-rails-pro']
+  end
+
+  def test_dependency_file_updater_accepts_base_packages_implied_by_direct_pro_packages
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'Gemfile'), <<~RUBY)
+      source 'https://rubygems.org'
+      gem 'react_on_rails_pro', '17.0.0.rc.9'
+    RUBY
+    package = { 'dependencies' => { 'react-on-rails-pro' => '17.0.0-rc.9' } }
+    File.write(File.join(dir, 'package.json'), JSON.pretty_generate(package))
+
+    DemoFleet::DependencyFileUpdater.new(
+      root: dir,
+      rubygems_versions: {
+        'react_on_rails' => '17.0.0.rc.10',
+        'react_on_rails_pro' => '17.0.0.rc.10'
+      },
+      npm_versions: {
+        'react-on-rails' => '17.0.0-rc.10',
+        'react-on-rails-pro' => '17.0.0-rc.10'
+      }
+    ).apply
+
+    assert_includes File.read(File.join(dir, 'Gemfile')), "gem 'react_on_rails_pro', '17.0.0.rc.10'"
+    package = JSON.parse(File.read(File.join(dir, 'package.json')))
+    assert_equal '17.0.0-rc.10', package['dependencies']['react-on-rails-pro']
+    refute package['dependencies'].key?('react-on-rails')
+  end
+
+  def test_dependency_file_updater_rejects_targets_missing_from_root_manifests
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'Gemfile'), "source 'https://rubygems.org'\n")
+    File.write(File.join(dir, 'package.json'), "{}\n")
+
+    gem_error = assert_raises(ArgumentError) do
+      DemoFleet::DependencyFileUpdater.new(
+        root: dir,
+        rubygems_versions: { 'react_on_rails' => '17.0.0.rc.10' },
+        npm_versions: {}
+      ).apply
+    end
+    npm_error = assert_raises(ArgumentError) do
+      DemoFleet::DependencyFileUpdater.new(
+        root: dir,
+        rubygems_versions: {},
+        npm_versions: { 'react-on-rails' => '17.0.0-rc.10' }
+      ).apply
+    end
+
+    assert_includes gem_error.message, 'is not declared'
+    assert_includes npm_error.message, 'is not declared'
+  end
+
+  def test_dependency_file_updater_does_not_allow_one_transitive_target_to_mask_another_missing_target
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'package.json'), "{}\n")
+
+    error = assert_raises(ArgumentError) do
+      DemoFleet::DependencyFileUpdater.new(
+        root: dir,
+        rubygems_versions: {},
+        npm_versions: {
+          'react-on-rails' => '17.0.0-rc.10',
+          'react-on-rails-pro' => '17.0.0-rc.10'
+        },
+        allowed_missing_npm_targets: ['react-on-rails']
+      ).apply
+    end
+
+    assert_includes error.message, 'react-on-rails-pro'
+  end
+
+  def test_dependency_file_updater_validates_all_targets_before_writing_either_file
+    dir = Dir.mktmpdir
+    original_gemfile = "source 'https://rubygems.org'\ngem 'react_on_rails', '16.0.0'\n"
+    File.write(File.join(dir, 'Gemfile'), original_gemfile)
+    File.write(File.join(dir, 'package.json'), "{}\n")
+
+    assert_raises(ArgumentError) do
+      DemoFleet::DependencyFileUpdater.new(
+        root: dir,
+        rubygems_versions: { 'react_on_rails' => '17.0.0.rc.10' },
+        npm_versions: { 'react-on-rails' => '17.0.0-rc.10' }
+      ).apply
+    end
+
+    assert_equal original_gemfile, File.read(File.join(dir, 'Gemfile'))
+  end
+
+  def test_update_plan_renders_freshness_commands_without_target_versions
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        package_manager: pnpm
+      repos:
+        - id: starter-rsc
+          github: shakacode/react-on-rails-rsc-demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: gem
+              name: shakapacker
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {},
+      npm_versions: {},
+      track: 'freshness',
+      date: Date.new(2026, 5, 27)
+    )
+
+    markdown = planner.to_markdown
+
+    assert_includes markdown, 'bundle update'
+    assert_includes markdown, 'pnpm update --latest'
+  end
+
+  def test_update_plan_refreshes_all_npm_dependencies_on_freshness_track
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        package_manager: npm
+      repos:
+        - id: npm-demo
+          github: shakacode/npm-demo
+          packages:
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {},
+      npm_versions: {},
+      track: 'freshness',
+      date: Date.new(2026, 5, 27)
+    )
+
+    assert_includes planner.to_markdown, 'npm-check-updates@19.1.1 --upgrade'
+    assert_includes planner.to_markdown, 'npm install'
+  end
+
+  def test_update_plan_filters_by_repo_id
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: marketplace-rsc
+          github: shakacode/react-on-rails-demo-marketplace-rsc
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+        - id: gumroad-rsc
+          github: shakacode/react-on-rails-demo-gumroad-rsc
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: { 'react_on_rails' => '16.7.0' },
+      npm_versions: {},
+      track: 'release',
+      repo_id: 'marketplace-rsc'
+    )
+
+    markdown = planner.to_markdown
+
+    assert_includes markdown, 'marketplace-rsc'
+    refute_includes markdown, 'gumroad-rsc'
+  end
+
+  def test_repo_filtered_update_plan_ignores_versions_for_packages_the_repo_does_not_consume
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: non-pro-demo
+          github: shakacode/non-pro-demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {
+        'react_on_rails' => '17.0.0.rc.10',
+        'react_on_rails_pro' => '17.0.0.rc.10'
+      },
+      npm_versions: { 'react-on-rails-rsc' => '19.2.1-rc.1' },
+      track: 'release',
+      repo_id: 'non-pro-demo'
+    )
+
+    planned_repo_ids = planner.plans.map { |plan| plan.repo.id }
+    assert_equal ['non-pro-demo'], planned_repo_ids
+  end
+
+  def test_update_plan_targets_base_packages_implied_by_direct_pro_packages
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: pro-only-demo
+          github: shakacode/pro-only-demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails_pro
+            - ecosystem: npm
+              name: react-on-rails-pro
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {
+        'react_on_rails' => '17.0.0.rc.10',
+        'react_on_rails_pro' => '17.0.0.rc.10'
+      },
+      npm_versions: {
+        'react-on-rails' => '17.0.0-rc.10',
+        'react-on-rails-pro' => '17.0.0-rc.10'
+      },
+      track: 'release'
+    )
+
+    command = planner.plans.first.dependency_commands.first
+    assert_includes command, '--gem react_on_rails\\=17.0.0.rc.10'
+    assert_includes command, '--gem react_on_rails_pro\\=17.0.0.rc.10'
+    assert_includes command, '--npm react-on-rails\\=17.0.0-rc.10'
+    assert_includes command, '--npm react-on-rails-pro\\=17.0.0-rc.10'
+  end
+
+  def test_update_plan_rejects_requested_targets_that_match_no_selected_repo
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: demo
+          github: shakacode/demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {
+        'react_on_rails' => '17.0.0.rc.10',
+        'react_on_rails_typo' => '17.0.0.rc.10'
+      },
+      npm_versions: {
+        'react-on-rails' => '17.0.0-rc.10',
+        'react-on-rails-typo' => '17.0.0-rc.10'
+      },
+      track: 'release'
+    )
+
+    error = assert_raises(ArgumentError) { planner.plans }
+
+    assert_includes error.message, 'gem:react_on_rails_typo'
+    assert_includes error.message, 'npm:react-on-rails-typo'
+  end
+
+  def test_supply_chain_policy_blocks_young_untrusted_versions
+    policy = DemoFleet::SupplyChainPolicy.new(
+      minimum_age_days: { 'freshness' => 7, 'release' => 0 },
+      trusted_targeted_packages: {
+        'rubygems' => ['react_on_rails'],
+        'npm' => ['react-on-rails']
+      }
+    )
+
+    now = Time.utc(2026, 5, 27, 12, 0, 0)
+    young_release = now - (2 * 24 * 60 * 60)
+    old_release = now - (8 * 24 * 60 * 60)
+
+    refute policy.allows_version?(
+      ecosystem: 'rubygems',
+      package_name: 'rails',
+      created_at: young_release,
+      track: 'freshness',
+      now: now,
+      targeted: false
+    )
+
+    assert policy.allows_version?(
+      ecosystem: 'rubygems',
+      package_name: 'rails',
+      created_at: old_release,
+      track: 'freshness',
+      now: now,
+      targeted: false
+    )
+
+    assert policy.allows_version?(
+      ecosystem: 'rubygems',
+      package_name: 'react_on_rails',
+      created_at: young_release,
+      track: 'release',
+      now: now,
+      targeted: true
+    )
+  end
+
+  def test_update_plan_uses_yarn_berry_update_syntax
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        package_manager: yarn_berry
+      repos:
+        - id: berry-demo
+          github: shakacode/berry-demo
+          packages:
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {},
+      npm_versions: {},
+      track: 'freshness'
+    )
+
+    assert_includes planner.to_markdown, "yarn up '*'"
+    refute_includes planner.to_markdown, 'yarn upgrade --latest'
+  end
+
+  def test_supply_chain_policy_only_bypasses_trusted_package_age_on_release_track
+    policy = DemoFleet::SupplyChainPolicy.new(
+      minimum_age_days: { 'freshness' => 7, 'release' => 7 },
+      trusted_targeted_packages: { 'rubygems' => ['react_on_rails'] }
+    )
+    created_at = Time.utc(2026, 5, 27, 11, 0, 0)
+    now = Time.utc(2026, 5, 27, 12, 0, 0)
+
+    refute policy.allows_version?(ecosystem: 'gem', package_name: 'react_on_rails', created_at: created_at,
+                                  track: 'freshness', now: now, targeted: true)
+    assert policy.allows_version?(ecosystem: 'gem', package_name: 'react_on_rails', created_at: created_at,
+                                  track: 'release', now: now, targeted: true)
+  end
+
+  def test_supply_chain_policy_rejects_unknown_selectors
+    policy = DemoFleet::SupplyChainPolicy.new(
+      minimum_age_days: { 'freshness' => 7 },
+      trusted_targeted_packages: {}
+    )
+    now = Time.utc(2026, 5, 27, 12, 0, 0)
+
+    track_error = assert_raises(ArgumentError) do
+      policy.allows_version?(ecosystem: 'npm', package_name: 'react', created_at: now - 3600,
+                             track: 'freshnes', now: now)
+    end
+    ecosystem_error = assert_raises(ArgumentError) do
+      policy.allows_version?(ecosystem: 'npn', package_name: 'react', created_at: now - 3600,
+                             track: 'freshness', now: now)
+    end
+
+    assert_includes track_error.message, 'unknown release track'
+    assert_includes ecosystem_error.message, 'unknown package ecosystem'
+  end
+
+  def test_manifest_policy_keeps_untrusted_release_packages_behind_age_gate
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        age_gate:
+          npm_min_days: 7
+          gem_min_days: 7
+          own_packages:
+            npm: [react-on-rails]
+            gem: [react_on_rails]
+      repos:
+        - id: demo
+          github: shakacode/demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+    policy = DemoFleet::SupplyChainPolicy.from_manifest(manifest)
+    now = Time.utc(2026, 5, 27, 12, 0, 0)
+
+    refute policy.allows_version?(ecosystem: 'gem', package_name: 'rails', created_at: now - 3600,
+                                  track: 'release', now: now, targeted: true)
+    assert policy.allows_version?(ecosystem: 'gem', package_name: 'react_on_rails', created_at: now - 3600,
+                                  track: 'release', now: now, targeted: true)
+  end
+
+  def test_manifest_policy_rejects_a_non_mapping_age_gate
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        age_gate: []
+      repos: []
+    YAML
+
+    error = assert_raises(ArgumentError) { DemoFleet::SupplyChainPolicy.from_manifest(manifest) }
+
+    assert_equal 'defaults.age_gate must be a mapping', error.message
+  end
+
+  def test_break_glass_override_expires_after_policy_window
+    policy = DemoFleet::SupplyChainPolicy.new(
+      minimum_age_days: { 'freshness' => 7 },
+      trusted_targeted_packages: {},
+      break_glass_days: 7
+    )
+
+    now = Time.utc(2026, 6, 1, 12, 0, 0)
+    expired_applied_at = Time.utc(2026, 5, 20, 12, 0, 0)
+    active_applied_at = Time.utc(2026, 5, 30, 12, 0, 0)
+
+    refute policy.break_glass_active?(applied_at: expired_applied_at, now: now)
+    assert policy.break_glass_active?(applied_at: active_applied_at, now: now)
+    refute policy.break_glass_active?(applied_at: now + 3600, now: now)
+  end
+
+  def test_break_glass_override_accepts_yaml_style_string_keys
+    policy = DemoFleet::SupplyChainPolicy.new(
+      minimum_age_days: { 'freshness' => 7 },
+      trusted_targeted_packages: {},
+      break_glass_days: 7
+    )
+    now = Time.utc(2026, 6, 1, 12, 0, 0)
+
+    assert policy.allows_version?(
+      ecosystem: 'npm',
+      package_name: 'react',
+      created_at: now - 3600,
+      track: 'freshness',
+      now: now,
+      break_glass: {
+        'applied_at' => now.iso8601,
+        'approved_by' => 'release-manager',
+        'tracking_issue' => 'https://github.com/shakacode/react_on_rails/issues/3823'
+      }
+    )
+  end
+
+  def test_runner_records_failures_without_stopping_gate_summary
+    repo_struct = Struct.new(:id)
+    plan_struct = Struct.new(:repo)
+    plans = [
+      plan_struct.new(repo_struct.new('good')),
+      plan_struct.new(repo_struct.new('bad'))
+    ]
+
+    runner = DemoFleet::Runner.new(concurrency: 2) do |plan|
+      raise 'boom' if plan.repo.id == 'bad'
+
+      'ok'
+    end
+
+    results = runner.run(plans)
+
+    assert_equal %w[good bad], results.map(&:repo_id)
+    assert_equal %w[success failure], results.map(&:status)
+    assert_equal 'boom', results.last.error
+  end
+
+  def test_review_app_lookup_is_executor_contract
+    lookup = DemoFleet::ReviewAppLookup.new
+
+    error = assert_raises(NotImplementedError) do
+      lookup.url_for(cpflow_app_name: 'demo-marketplace-rsc', branch_name: 'demo-fleet/release')
+    end
+
+    assert_includes error.message, 'CPFlow URL lookup'
+  end
+
+  def test_executor_command_plan_clones_updates_verifies_and_prepares_pr
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      defaults:
+        package_manager: pnpm
+      repos:
+        - id: marketplace-rsc
+          github: shakacode/react-on-rails-demo-marketplace-rsc
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: npm
+              name: react-on-rails
+          trust_mise: true
+          verify_template: templates/demo-repo/marketplace-rsc/script/demo-fleet-verify
+          verify_commands:
+            - script/demo-fleet-verify
+    YAML
+
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: { 'react_on_rails' => '16.7.0' },
+      npm_versions: { 'react-on-rails' => '16.7.0' },
+      track: 'release',
+      date: Date.new(2026, 6, 1)
+    )
+    plan = planner.plans.first
+    executor = DemoFleet::Executor.new(workspace: '/tmp/demo-fleet', allow_remote_prs: true)
+
+    commands = executor.commands_for(plan)
+
+    assert_equal(
+      ['gh', 'repo', 'clone', 'shakacode/react-on-rails-demo-marketplace-rsc',
+       '/tmp/demo-fleet/marketplace-rsc'],
+      commands[1].argv
+    )
+    assert(commands.any? { |command| command.argv == ['mise', 'trust', '/tmp/demo-fleet/marketplace-rsc/mise.toml'] })
+    assert(commands.any? { |command| command.argv == ['mkdir', '-p', '/tmp/demo-fleet/marketplace-rsc/script'] })
+    assert(commands.any? do |command|
+      command.argv[0] == 'cp' &&
+        command.argv[1].include?('templates/demo-repo/marketplace-rsc/script/demo-fleet-verify')
+    end)
+    assert(commands.any? do |command|
+      command.argv == ['chmod', '+x', '/tmp/demo-fleet/marketplace-rsc/script/demo-fleet-verify']
+    end)
+    apply_command = commands.find { |command| command.argv.include?('--gem') }
+
+    assert_equal '/tmp/demo-fleet/marketplace-rsc', apply_command.cwd
+    assert_equal ['mise', 'exec', '--', 'ruby'], apply_command.argv[0, 4]
+    assert_includes apply_command.argv[4], 'demo-fleet-apply-versions'
+    assert_includes apply_command.argv, 'react_on_rails=16.7.0'
+    refute_includes apply_command.argv, '--allow-missing-npm-target'
+    assert(commands.any? { |command| command.argv == ['mise', 'exec', '--', 'bundle', 'update', 'react_on_rails'] })
+    assert(commands.any? do |command|
+      command.argv.first(5) == ['mise', 'exec', '--', 'bash', '-lc'] && command.argv.last.include?('pnpm install')
+    end)
+    assert(commands.any? do |command|
+      command.argv == ['mise', 'exec', '--', 'bash', '-lc', 'script/demo-fleet-verify']
+    end)
+    assert(commands.any? { |command| command.description == 'Open or reuse draft demo update PR' })
+  end
+
+  def test_update_plan_only_allows_explicitly_transitive_npm_targets_to_be_missing
+    manifest = DemoFleet::Manifest.from_file(write_yaml(<<~YAML))
+      schema_version: 1
+      repos:
+        - id: demo
+          github: shakacode/demo
+          packages:
+            - ecosystem: npm
+              name: react-on-rails
+            - ecosystem: npm
+              name: react-on-rails-pro
+          transitive_only_npm_packages:
+            - react-on-rails
+    YAML
+    planner = DemoFleet::UpdatePlanner.new(
+      manifest: manifest,
+      rubygems_versions: {},
+      npm_versions: {
+        'react-on-rails' => '17.0.0-rc.10',
+        'react-on-rails-pro' => '17.0.0-rc.10'
+      },
+      track: 'release'
+    )
+
+    command = planner.plans.first.dependency_commands.first
+
+    assert_includes command, '--allow-missing-npm-target react-on-rails'
+    refute_includes command, '--allow-missing-npm-target react-on-rails-pro'
+  end
+
+  def test_generated_package_install_loop_is_valid_shell
+    Dir.mktmpdir do |repo_path|
+      system('git', 'init', '--quiet', repo_path)
+      configure_test_git(repo_path)
+      File.write(File.join(repo_path, 'package.json'), "{}\n")
+      system('git', '-C', repo_path, 'add', 'package.json')
+      system('git', '-C', repo_path, 'commit', '--quiet', '-m', 'base')
+      File.write(File.join(repo_path, 'package.json'), "{\"private\":true}\n")
+      plan = DemoFleet::RepoUpdatePlan.allocate
+      generated_command = plan.send(:install_changed_package_manifests_command, 'true')
+
+      _stdout, stderr, status = Open3.capture3(*Shellwords.split(generated_command), chdir: repo_path)
+
+      assert status.success?, stderr
+    end
+  end
+
+  def test_executor_runs_shell_style_verification_commands_through_a_shell
+    repo = Struct.new(:id, :github, :branch_prefix, :tier).new('demo', 'shakacode/demo', 'demo-fleet', 'hard_gate')
+    plan = Struct.new(:repo, :branch_name, :dependency_commands, :verify_commands, :smoke_urls).new(
+      repo,
+      'demo-fleet/release-20260601-demo',
+      [],
+      ['ALLOW_FAILURES=true bin/rails test', 'cd client && yarn build'],
+      ['/']
+    )
+
+    commands = DemoFleet::Executor.new(workspace: '/tmp/demo-fleet').commands_for(plan)
+
+    assert(commands.any? { |command| command.argv == ['bash', '-lc', 'ALLOW_FAILURES=true bin/rails test'] })
+    assert(commands.any? { |command| command.argv == ['bash', '-lc', 'cd client && yarn build'] })
+  end
+
+  def test_executor_reuses_an_existing_checkout
+    Dir.mktmpdir do |workspace|
+      repo_path = File.join(workspace, 'demo')
+      FileUtils.mkdir_p(File.join(repo_path, '.git'))
+      repo = Struct.new(:id, :github, :branch_prefix, :tier).new('demo', 'shakacode/demo', 'demo-fleet', 'hard_gate')
+      plan = Struct.new(:repo, :branch_name, :dependency_commands, :verify_commands, :smoke_urls).new(
+        repo, 'demo-fleet/release-20260601-demo', [], [], []
+      )
+
+      commands = DemoFleet::Executor.new(workspace: workspace).commands_for(plan)
+
+      refute(commands.any? { |command| command.argv.first(3) == %w[gh repo clone] })
+      origin_check = commands.find { |command| command.description == 'Verify demo checkout origin' }
+      clean_check = commands.find { |command| command.description == 'Require a clean demo checkout' }
+      fetch_command = commands.find { |command| command.argv == %w[git fetch --prune origin] }
+      branch_command = commands.find { |command| command.description == 'Create or reuse update branch' }
+      assert_equal ['demo-fleet', 'shakacode/demo'], origin_check.argv.last(2)
+      assert_operator commands.index(origin_check), :<, commands.index(clean_check)
+      assert_operator commands.index(clean_check), :<, commands.index(fetch_command)
+      assert_operator commands.index(fetch_command), :<, commands.index(branch_command)
+      refute_nil fetch_command
+      refute_nil branch_command
+    end
+  end
+
+  def test_executor_fast_forwards_a_reused_local_update_branch
+    Dir.mktmpdir do |workspace|
+      remote = File.join(workspace, 'remote.git')
+      seed = File.join(workspace, 'seed')
+      checkout = File.join(workspace, 'checkout')
+      branch = 'demo-fleet/release-20260601-demo'
+
+      system('git', 'init', '--bare', '--quiet', '--initial-branch=main', remote)
+      system('git', 'clone', '--quiet', remote, seed)
+      configure_test_git(seed)
+      File.write(File.join(seed, 'README.md'), "base\n")
+      system('git', '-C', seed, 'add', 'README.md')
+      system('git', '-C', seed, 'commit', '--quiet', '-m', 'base')
+      system('git', '-C', seed, 'push', '--quiet', 'origin', 'HEAD:main')
+      system('git', '-C', seed, 'checkout', '--quiet', '-b', branch)
+      File.write(File.join(seed, 'README.md'), "base\nfirst\n")
+      system('git', '-C', seed, 'commit', '--quiet', '-am', 'first')
+      system('git', '-C', seed, 'push', '--quiet', '-u', 'origin', branch)
+
+      system('git', 'clone', '--quiet', remote, checkout)
+      system('git', '-C', checkout, 'checkout', '--quiet', '-b', branch, "origin/#{branch}")
+      File.write(File.join(seed, 'README.md'), "base\nfirst\nsecond\n")
+      system('git', '-C', seed, 'commit', '--quiet', '-am', 'second')
+      system('git', '-C', seed, 'push', '--quiet')
+      system('git', '-C', checkout, 'fetch', '--quiet', 'origin')
+
+      command = checkout_branch_command_for(checkout, branch)
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: checkout)
+
+      assert status.success?, stderr
+      assert_equal git_revision(checkout, "origin/#{branch}"), git_revision(checkout, 'HEAD')
+    end
+  end
+
+  def test_executor_preserves_an_inspected_local_only_branch_for_later_publication
+    Dir.mktmpdir do |workspace|
+      remote = File.join(workspace, 'remote.git')
+      seed = File.join(workspace, 'seed')
+      checkout = File.join(workspace, 'checkout')
+      branch = 'demo-fleet/release-20260601-demo'
+
+      system('git', 'init', '--bare', '--quiet', '--initial-branch=main', remote)
+      system('git', 'clone', '--quiet', remote, seed)
+      configure_test_git(seed)
+      File.write(File.join(seed, 'README.md'), "base\n")
+      system('git', '-C', seed, 'add', 'README.md')
+      system('git', '-C', seed, 'commit', '--quiet', '-m', 'base')
+      system('git', '-C', seed, 'push', '--quiet', 'origin', 'HEAD:main')
+
+      system('git', 'clone', '--quiet', remote, checkout)
+      system('git', '-C', checkout, 'checkout', '--quiet', '-b', branch, 'origin/HEAD')
+      configure_test_git(checkout)
+      File.write(File.join(checkout, 'README.md'), "base\ninspected update\n")
+      system('git', '-C', checkout, 'commit', '--quiet', '-am', 'inspected update')
+      inspected_revision = git_revision(checkout, 'HEAD')
+
+      File.write(File.join(seed, 'README.md'), "base\nnew main\n")
+      system('git', '-C', seed, 'commit', '--quiet', '-am', 'advance main')
+      system('git', '-C', seed, 'push', '--quiet', 'origin', 'HEAD:main')
+      system('git', '-C', checkout, 'fetch', '--quiet', '--prune', 'origin')
+
+      command = checkout_branch_command_for(checkout, branch)
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: checkout)
+
+      assert status.success?, stderr
+      assert_equal inspected_revision, git_revision(checkout, 'HEAD')
+      refute_equal git_revision(checkout, 'origin/HEAD'), git_revision(checkout, 'HEAD')
+    end
+  end
+
+  def test_executor_resets_a_stale_local_branch_after_its_remote_was_deleted
+    Dir.mktmpdir do |workspace|
+      _remote, seed, checkout, branch = create_pushed_update_branch(workspace)
+
+      system('git', '-C', seed, 'checkout', '--quiet', 'main')
+      File.write(File.join(seed, 'README.md'), "new main\n")
+      system('git', '-C', seed, 'commit', '--quiet', '-am', 'advance main')
+      system('git', '-C', seed, 'push', '--quiet', 'origin', 'main')
+      system('git', '-C', seed, 'push', '--quiet', 'origin', ":#{branch}")
+      system('git', '-C', checkout, 'fetch', '--quiet', '--prune', 'origin')
+
+      command = checkout_branch_command_for(checkout, branch)
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: checkout)
+
+      assert status.success?, stderr
+      assert_equal git_revision(checkout, 'origin/HEAD'), git_revision(checkout, 'HEAD')
+    end
+  end
+
+  def test_executor_accepts_authenticated_github_origins_without_echoing_credentials
+    Dir.mktmpdir do |workspace|
+      repo_path = File.join(workspace, 'demo')
+      FileUtils.mkdir_p(repo_path)
+      system('git', 'init', '--quiet', repo_path)
+      system('git', '-C', repo_path, 'remote', 'add', 'origin',
+             'https://x-access-token:secret@github.com/shakacode/demo.git')
+      repo = Struct.new(:github).new('shakacode/demo')
+      command = DemoFleet::Executor.new(workspace: workspace).send(:verify_origin_command, repo, repo_path)
+
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: repo_path)
+
+      assert status.success?, stderr
+      refute_includes stderr, 'secret'
+    end
+  end
+
+  def test_executor_rejects_a_reused_checkout_with_the_wrong_origin
+    Dir.mktmpdir do |workspace|
+      repo_path = File.join(workspace, 'demo')
+      FileUtils.mkdir_p(repo_path)
+      system('git', 'init', '--quiet', repo_path)
+      system('git', '-C', repo_path, 'remote', 'add', 'origin', 'https://github.com/shakacode/wrong-demo.git')
+      repo = Struct.new(:id, :github, :branch_prefix, :tier).new(
+        'demo', 'shakacode/demo', 'demo-fleet', 'hard_gate'
+      )
+      plan = Struct.new(:repo, :branch_name, :dependency_commands, :verify_commands, :smoke_urls).new(
+        repo, 'demo-fleet/release-20260601-demo', [], [], []
+      )
+      commands = DemoFleet::Executor.new(workspace: workspace).commands_for(plan)
+      origin_check = commands.find { |command| command.description == 'Verify demo checkout origin' }
+
+      _stdout, stderr, status = Open3.capture3(*origin_check.argv, chdir: repo_path)
+
+      refute status.success?
+      assert_includes stderr, 'origin remote does not match expected repository shakacode/demo'
+    end
+  end
+
+  def test_executor_skips_no_op_commit_and_remote_commands
+    shell = RecordingShell.new(staged_changes: false, branch_has_commits: false)
+    executor = DemoFleet::Executor.new(workspace: '/tmp/demo-fleet', allow_remote_prs: true, shell: shell)
+
+    outcome = executor.execute(executor_test_plan)
+
+    refute(outcome.commands.any? { |command| command.phase == :commit })
+    refute(outcome.commands.any? { |command| REMOTE_PHASES.include?(command.phase) })
+  end
+
+  def test_executor_only_stages_dependency_update_files
+    commands = DemoFleet::Executor.new(workspace: '/tmp/demo-fleet').commands_for(executor_test_plan)
+    stage_command = commands.find { |command| command.description == 'Stage dependency update files' }
+
+    assert_equal %w[bash -lc], stage_command.argv.first(2)
+    assert_includes stage_command.argv.last, 'Gemfile.lock'
+    assert_includes stage_command.argv.last, 'script/demo-fleet-verify'
+    refute(commands.any? { |command| command.argv == %w[git add --all] })
+  end
+
+  def test_executor_rejects_tracked_files_outside_the_dependency_allowlist
+    Dir.mktmpdir do |repo_path|
+      system('git', 'init', '--quiet', repo_path)
+      configure_test_git(repo_path)
+      File.write(File.join(repo_path, 'Gemfile'), "source 'https://rubygems.org'\n")
+      File.write(File.join(repo_path, 'README.md'), "base\n")
+      system('git', '-C', repo_path, 'add', 'Gemfile', 'README.md')
+      system('git', '-C', repo_path, 'commit', '--quiet', '-m', 'base')
+      File.write(File.join(repo_path, 'Gemfile'), "source 'https://rubygems.org'\n# updated\n")
+      File.write(File.join(repo_path, 'README.md'), "unrelated\n")
+
+      executor = DemoFleet::Executor.new(workspace: File.dirname(repo_path))
+      command = executor.send(:stage_dependency_files_command, repo_path)
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: repo_path)
+
+      refute status.success?
+      assert_includes stderr, 'outside the dependency allowlist'
+      assert_empty Open3.capture2('git', '-C', repo_path, 'diff', '--cached', '--name-only').first
+    end
+  end
+
+  def test_executor_rejects_untracked_files_outside_the_dependency_allowlist
+    Dir.mktmpdir do |repo_path|
+      system('git', 'init', '--quiet', repo_path)
+      configure_test_git(repo_path)
+      File.write(File.join(repo_path, 'Gemfile'), "source 'https://rubygems.org'\n")
+      system('git', '-C', repo_path, 'add', 'Gemfile')
+      system('git', '-C', repo_path, 'commit', '--quiet', '-m', 'base')
+      File.write(File.join(repo_path, 'Gemfile'), "source 'https://rubygems.org'\n# updated\n")
+      File.write(File.join(repo_path, 'unexpected.txt'), "generated\n")
+
+      command = DemoFleet::Executor.new(workspace: File.dirname(repo_path)).send(
+        :stage_dependency_files_command, repo_path
+      )
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: repo_path)
+
+      refute status.success?
+      assert_includes stderr, 'unexpected.txt'
+      assert_empty Open3.capture2('git', '-C', repo_path, 'diff', '--cached', '--name-only').first
+    end
+  end
+
+  def test_executor_stages_yarn_berry_pnp_artifacts
+    Dir.mktmpdir do |repo_path|
+      system('git', 'init', '--quiet', repo_path)
+      configure_test_git(repo_path)
+      FileUtils.mkdir_p(File.join(repo_path, '.yarn', 'cache'))
+      File.write(File.join(repo_path, 'package.json'), "{}\n")
+      system('git', '-C', repo_path, 'add', 'package.json')
+      system('git', '-C', repo_path, 'commit', '--quiet', '-m', 'base')
+      File.write(File.join(repo_path, '.pnp.cjs'), "generated\n")
+      File.write(File.join(repo_path, '.pnp.loader.mjs'), "generated\n")
+      File.write(File.join(repo_path, '.yarn', 'cache', 'react-on-rails.zip'), "generated\n")
+      File.write(File.join(repo_path, '.yarn', 'install-state.gz'), "generated\n")
+
+      command = DemoFleet::Executor.new(workspace: File.dirname(repo_path)).send(
+        :stage_dependency_files_command, repo_path
+      )
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: repo_path)
+
+      assert status.success?, stderr
+      assert_equal %w[.pnp.cjs .pnp.loader.mjs .yarn/cache/react-on-rails.zip .yarn/install-state.gz],
+                   Open3.capture2('git', '-C', repo_path, 'diff', '--cached', '--name-only').first.lines.map(&:strip)
+    end
+  end
+
+  def test_release_plan_workflow_exercises_executor_dry_run
+    workflow = File.read(File.expand_path('../.github/workflows/demo-fleet-release-plan.yml', __dir__))
+
+    assert_includes workflow, 'script/demo-fleet execute-plan --dry-run "${args[@]}"'
+    refute_includes workflow, 'script/demo-fleet update-plan "${args[@]}"'
+  end
+
+  def test_executor_rejects_files_staged_outside_the_dependency_allowlist
+    Dir.mktmpdir do |repo_path|
+      system('git', 'init', '--quiet', repo_path)
+      configure_test_git(repo_path)
+      File.write(File.join(repo_path, 'Gemfile'), "source 'https://rubygems.org'\n")
+      File.write(File.join(repo_path, 'README.md'), "base\n")
+      system('git', '-C', repo_path, 'add', 'Gemfile', 'README.md')
+      system('git', '-C', repo_path, 'commit', '--quiet', '-m', 'base')
+      File.write(File.join(repo_path, 'Gemfile'), "source 'https://rubygems.org'\n# updated\n")
+      File.write(File.join(repo_path, 'README.md'), "unexpected\n")
+      system('git', '-C', repo_path, 'add', 'README.md')
+
+      command = DemoFleet::Executor.new(workspace: File.dirname(repo_path)).send(
+        :stage_dependency_files_command, repo_path
+      )
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: repo_path)
+
+      refute status.success?
+      assert_includes stderr, 'README.md'
+      assert_equal "README.md\n", Open3.capture2('git', '-C', repo_path, 'diff', '--cached', '--name-only').first
+    end
+  end
+
+  def test_executor_stages_nested_package_manifests_and_lockfiles
+    Dir.mktmpdir do |repo_path|
+      system('git', 'init', '--quiet', repo_path)
+      configure_test_git(repo_path)
+      FileUtils.mkdir_p(File.join(repo_path, 'client'))
+      File.write(File.join(repo_path, 'client', 'package.json'), "{}\n")
+      File.write(File.join(repo_path, 'client', 'yarn.lock'), "base\n")
+      system('git', '-C', repo_path, 'add', 'client/package.json', 'client/yarn.lock')
+      system('git', '-C', repo_path, 'commit', '--quiet', '-m', 'base')
+      File.write(File.join(repo_path, 'client', 'package.json'), "{\"private\":true}\n")
+      File.write(File.join(repo_path, 'client', 'yarn.lock'), "updated\n")
+
+      command = DemoFleet::Executor.new(workspace: File.dirname(repo_path)).send(
+        :stage_dependency_files_command, repo_path
+      )
+      _stdout, stderr, status = Open3.capture3(*command.argv, chdir: repo_path)
+
+      assert status.success?, stderr
+      assert_equal %w[client/package.json client/yarn.lock],
+                   Open3.capture2('git', '-C', repo_path, 'diff', '--cached', '--name-only').first.lines.map(&:strip)
+    end
+  end
+
+  def test_executor_pushes_an_existing_unpushed_branch_without_a_new_commit
+    shell = RecordingShell.new(staged_changes: false, branch_has_commits: true)
+    executor = DemoFleet::Executor.new(workspace: '/tmp/demo-fleet', allow_remote_prs: true, shell: shell)
+
+    outcome = executor.execute(executor_test_plan)
+
+    refute(outcome.commands.any? { |command| command.phase == :commit })
+    remote_phases = outcome.commands.filter_map do |command|
+      command.phase if REMOTE_PHASES.include?(command.phase)
+    end
+    assert_equal %i[push open_pr], remote_phases
+  end
+
+  def test_executor_opens_a_pr_for_an_already_pushed_release_branch
+    shell = RecordingShell.new(
+      staged_changes: false,
+      branch_has_commits: false,
+      branch_has_release_commits: true
+    )
+    executor = DemoFleet::Executor.new(workspace: '/tmp/demo-fleet', allow_remote_prs: true, shell: shell)
+
+    outcome = executor.execute(executor_test_plan)
+
+    refute(outcome.commands.any? { |command| command.phase == :push })
+    assert(outcome.commands.any? { |command| command.phase == :open_pr })
+  end
+
+  def test_shell_only_reports_commits_ahead_of_the_tracked_update_branch
+    Dir.mktmpdir do |workspace|
+      _remote, _seed, checkout, _branch = create_pushed_update_branch(workspace)
+      shell = DemoFleet::Shell.new
+
+      refute shell.branch_has_commits?(checkout)
+      assert shell.branch_has_release_commits?(checkout)
+
+      configure_test_git(checkout)
+      File.write(File.join(checkout, 'README.md'), "local update\n")
+      system('git', '-C', checkout, 'commit', '--quiet', '-am', 'local update')
+
+      assert shell.branch_has_commits?(checkout)
+      assert shell.branch_has_release_commits?(checkout)
+    end
+  end
+
+  def test_executor_command_plan_omits_remote_pr_commands_without_remote_permission
+    repo = Struct.new(:id, :github, :branch_prefix, :tier).new('demo', 'shakacode/demo', 'demo-fleet', 'hard_gate')
+    plan = Struct.new(:repo, :branch_name, :dependency_commands, :verify_commands, :smoke_urls).new(
+      repo,
+      'demo-fleet/release-20260601-demo',
+      ['bundle add react_on_rails --version 16.7.0'],
+      ['script/demo-fleet-verify'],
+      ['/']
+    )
+    executor = DemoFleet::Executor.new(workspace: '/tmp/demo-fleet', allow_remote_prs: false)
+
+    commands = executor.commands_for(plan)
+
+    refute(commands.any? { |command| command.argv.include?('push') })
+    refute(commands.any? { |command| command.argv[0, 3] == %w[gh pr create] })
+  end
+
+  def test_cli_validate_reports_manifest_status
+    manifest_path = write_yaml(<<~YAML)
+      schema_version: 1
+      defaults:
+        package_manager: pnpm
+      repos:
+        - id: ssr-hmr
+          github: shakacode/react-on-rails-demo-ssr-hmr
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+
+    out = StringIO.new
+    err = StringIO.new
+    status = DemoFleet::CLI.run(['validate', '--manifest', manifest_path], out: out, err: err)
+
+    assert_equal 0, status
+    assert_includes out.string, '1 actionable repos, 0 pending verification'
+    assert_empty err.string
+  end
+
+  def test_cli_validate_reports_missing_manifest_without_a_backtrace
+    missing_path = File.join(Dir.tmpdir, "missing-demo-fleet-#{Process.pid}.yml")
+    out = StringIO.new
+    err = StringIO.new
+
+    status = DemoFleet::CLI.run(['validate', '--manifest', missing_path], out: out, err: err)
+
+    assert_equal 1, status
+    assert_includes err.string, "Unable to load manifest from #{missing_path}"
+    refute_includes err.string, "\tfrom "
+    assert_empty out.string
+  end
+
+  def test_cli_validate_reports_malformed_manifest_without_a_backtrace
+    malformed_dir = Dir.mktmpdir
+    malformed_path = File.join(malformed_dir, 'manifest.yml')
+    File.write(malformed_path, "schema_version: [\n")
+    out = StringIO.new
+    err = StringIO.new
+
+    status = DemoFleet::CLI.run(['validate', '--manifest', malformed_path], out: out, err: err)
+
+    assert_equal 1, status
+    assert_includes err.string, "Unable to parse manifest from #{malformed_path}"
+    refute_includes err.string, "\tfrom "
+    assert_empty out.string
+  end
+
+  def test_cli_validate_reports_structurally_invalid_manifest_without_a_backtrace
+    invalid_path = write_yaml("schema_version: 1\ndefaults: []\nrepos: []\n", with_default_review_app: false)
+    out = StringIO.new
+    err = StringIO.new
+
+    status = DemoFleet::CLI.run(['validate', '--manifest', invalid_path], out: out, err: err)
+
+    assert_equal 1, status
+    assert_includes err.string, 'defaults must be a mapping'
+    refute_includes err.string, "\tfrom "
+    assert_empty out.string
+  end
+
+  def test_cli_execute_plan_dry_run_reports_an_empty_unverified_selection
+    manifest_path = write_yaml(<<~YAML)
+      schema_version: 1
+      repos:
+        - id: draft-demo
+          github: shakacode/draft-demo
+          verify: true
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+    out = StringIO.new
+    err = StringIO.new
+
+    status = DemoFleet::CLI.run(
+      [
+        'execute-plan', '--manifest', manifest_path, '--track', 'release', '--dry-run',
+        '--gem', 'react_on_rails=17.0.0.rc.10'
+      ],
+      out: out,
+      err: err
+    )
+
+    assert_equal 0, status
+    assert_includes out.string, '- Mode: `dry-run`'
+    assert_includes out.string, '- Repositories: `0`'
+    assert_empty err.string
+  end
+
+  def test_cli_update_plan_writes_markdown
+    manifest_path = write_yaml(<<~YAML)
+      schema_version: 1
+      defaults:
+        package_manager: pnpm
+      repos:
+        - id: marketplace-rsc
+          github: shakacode/react-on-rails-demo-marketplace-rsc
+          tier: hard_gate
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    out = StringIO.new
+    err = StringIO.new
+    status = DemoFleet::CLI.run(
+      [
+        'update-plan',
+        '--manifest', manifest_path,
+        '--track', 'release',
+        '--date', '2026-05-27',
+        '--gem', 'react_on_rails=16.7.0',
+        '--npm', 'react-on-rails=16.7.0'
+      ],
+      out: out,
+      err: err
+    )
+
+    assert_equal 0, status
+    assert_includes out.string, '# Demo Fleet Update Plan'
+    assert_includes out.string, 'demo-fleet-apply-versions'
+    assert_includes out.string, 'bundle update react_on_rails'
+    assert_includes out.string, 'pnpm install'
+    assert_empty err.string
+  end
+
+  def test_cli_execute_plan_dry_run_writes_per_repo_status
+    manifest_path = write_yaml(<<~YAML)
+      schema_version: 1
+      defaults:
+        package_manager: pnpm
+      repos:
+        - id: marketplace-rsc
+          github: shakacode/react-on-rails-demo-marketplace-rsc
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+            - ecosystem: npm
+              name: react-on-rails
+    YAML
+
+    out = StringIO.new
+    err = StringIO.new
+    status = DemoFleet::CLI.run(
+      [
+        'execute-plan',
+        '--manifest', manifest_path,
+        '--track', 'release',
+        '--repo', 'marketplace-rsc',
+        '--dry-run',
+        '--gem', 'react_on_rails=16.7.0',
+        '--npm', 'react-on-rails=16.7.0'
+      ],
+      out: out,
+      err: err
+    )
+
+    assert_equal 0, status
+    assert_includes out.string, '| Repo | Status | Branch |'
+    assert_includes out.string, '| `marketplace-rsc` | `success` | `demo-fleet/release-'
+    refute_includes out.string, 'gumroad-rsc'
+    assert_empty err.string
+  end
+
+  def test_cli_execute_plan_requires_workspace_for_execute_mode
+    out = StringIO.new
+    err = StringIO.new
+    status = DemoFleet::CLI.run(['execute-plan', '--execute'], out: out, err: err)
+
+    assert_equal 1, status
+    assert_includes err.string, '--workspace is required for --execute'
+    assert_empty out.string
+  end
+
+  def test_cli_execute_plan_rejects_freshness_mutation_until_age_gate_is_enforced
+    out = StringIO.new
+    err = StringIO.new
+    status = DemoFleet::CLI.run(
+      ['execute-plan', '--track', 'freshness', '--execute', '--workspace', '/tmp/demo-fleet'],
+      out: out,
+      err: err
+    )
+
+    assert_equal 1, status
+    assert_includes err.string, 'freshness execution is disabled'
+    assert_empty out.string
+  end
+
+  def test_cli_release_plan_requires_target_versions
+    manifest_path = write_yaml(<<~YAML)
+      schema_version: 1
+      repos:
+        - id: demo
+          github: shakacode/demo
+          packages:
+            - ecosystem: gem
+              name: react_on_rails
+    YAML
+    out = StringIO.new
+    err = StringIO.new
+
+    status = DemoFleet::CLI.run(
+      ['execute-plan', '--manifest', manifest_path, '--track', 'release', '--dry-run'],
+      out: out,
+      err: err
+    )
+
+    assert_equal 1, status
+    assert_includes err.string, 'release track requires at least one'
+    assert_empty out.string
+  end
+
+  def test_cli_age_check_blocks_young_untrusted_package
+    policy_path = write_yaml(<<~YAML)
+      minimum_age_days:
+        freshness: 7
+      trusted_targeted_packages:
+        rubygems:
+          - react_on_rails
+    YAML
+
+    out = StringIO.new
+    err = StringIO.new
+    status = DemoFleet::CLI.run(
+      [
+        'age-check',
+        '--policy', policy_path,
+        '--ecosystem', 'rubygems',
+        '--package', 'rails',
+        '--created-at', '2026-05-25T12:00:00Z',
+        '--track', 'freshness',
+        '--now', '2026-05-27T12:00:00Z'
+      ],
+      out: out,
+      err: err
+    )
+
+    assert_equal 2, status
+    assert_includes err.string, 'blocked by age policy'
+    assert_empty out.string
+  end
+
+  def test_cli_age_check_reports_the_defined_package_flag_when_missing
+    out = StringIO.new
+    err = StringIO.new
+
+    status = DemoFleet::CLI.run(
+      ['age-check', '--ecosystem', 'rubygems', '--created-at', '2026-05-25T12:00:00Z'],
+      out: out,
+      err: err
+    )
+
+    assert_equal 1, status
+    assert_includes err.string, '--package is required'
+    refute_includes err.string, '--package-name'
+    assert_empty out.string
+  end
+
+  def test_cli_age_check_allows_trusted_targeted_package
+    policy_path = write_yaml(<<~YAML)
+      minimum_age_days:
+        freshness: 7
+      trusted_targeted_packages:
+        rubygems:
+          - react_on_rails
+    YAML
+
+    out = StringIO.new
+    err = StringIO.new
+    status = DemoFleet::CLI.run(
+      [
+        'age-check',
+        '--policy', policy_path,
+        '--ecosystem', 'rubygems',
+        '--package', 'react_on_rails',
+        '--created-at', '2026-05-27T11:00:00Z',
+        '--track', 'release',
+        '--now', '2026-05-27T12:00:00Z',
+        '--targeted'
+      ],
+      out: out,
+      err: err
+    )
+
+    assert_equal 0, status
+    assert_includes out.string, 'allowed by age policy'
+    assert_empty err.string
+  end
+
+  private
+
+  def checkout_branch_command_for(repo_path, branch)
+    repo = Struct.new(:id, :github, :branch_prefix, :tier).new('demo', 'shakacode/demo', 'demo-fleet', 'hard_gate')
+    plan = Struct.new(:repo, :branch_name, :dependency_commands, :verify_commands, :smoke_urls).new(
+      repo, branch, [], [], []
+    )
+    DemoFleet::Executor.new(workspace: File.dirname(repo_path)).commands_for(plan).find do |command|
+      command.description == 'Create or reuse update branch'
+    end
+  end
+
+  def configure_test_git(repo_path)
+    system('git', '-C', repo_path, 'config', 'user.email', 'demo-fleet@example.com')
+    system('git', '-C', repo_path, 'config', 'user.name', 'Demo Fleet Test')
+  end
+
+  def create_pushed_update_branch(workspace)
+    remote = File.join(workspace, 'remote.git')
+    seed = File.join(workspace, 'seed')
+    checkout = File.join(workspace, 'checkout')
+    branch = 'demo-fleet/release-20260601-demo'
+
+    system('git', 'init', '--bare', '--quiet', '--initial-branch=main', remote)
+    system('git', 'clone', '--quiet', remote, seed)
+    configure_test_git(seed)
+    File.write(File.join(seed, 'README.md'), "base\n")
+    system('git', '-C', seed, 'add', 'README.md')
+    system('git', '-C', seed, 'commit', '--quiet', '-m', 'base')
+    system('git', '-C', seed, 'push', '--quiet', 'origin', 'HEAD:main')
+    system('git', '-C', seed, 'checkout', '--quiet', '-b', branch)
+    File.write(File.join(seed, 'README.md'), "old branch\n")
+    system('git', '-C', seed, 'commit', '--quiet', '-am', 'old branch')
+    system('git', '-C', seed, 'push', '--quiet', '-u', 'origin', branch)
+    system('git', 'clone', '--quiet', remote, checkout)
+    system('git', '-C', checkout, 'checkout', '--quiet', '-b', branch, "origin/#{branch}")
+
+    [remote, seed, checkout, branch]
+  end
+
+  def git_revision(repo_path, revision)
+    Open3.capture2('git', '-C', repo_path, 'rev-parse', revision).first.strip
+  end
+
+  def executor_test_plan
+    repo = Struct.new(:id, :github, :branch_prefix, :tier).new('demo', 'shakacode/demo', 'demo-fleet', 'hard_gate')
+    Struct.new(:repo, :branch_name, :dependency_commands, :verify_commands, :smoke_urls).new(
+      repo,
+      'demo-fleet/release-20260601-demo',
+      [],
+      [],
+      []
+    )
+  end
+
+  def write_yaml(contents, with_default_review_app: true)
+    data = YAML.safe_load(contents, aliases: true)
+    if with_default_review_app && data.is_a?(Hash) && data['schema_version'] == 1 && data['repos'].is_a?(Array)
+      defaults = data['defaults'] ||= {}
+      defaults['review_app'] ||= { 'cpflow_app_name' => 'fixture-review-app' } if defaults.is_a?(Hash)
+      contents = YAML.dump(data)
+    end
+
+    dir = Dir.mktmpdir
+    path = File.join(dir, 'input.yml')
+    File.write(path, contents)
+    path
+  end
+end

--- a/test/fixtures/demo-fleet.yml
+++ b/test/fixtures/demo-fleet.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+
+defaults:
+  package_manager: pnpm
+  branch_prefix: demo-fleet
+  review_app:
+    cpflow_app_name: fixture-demo
+  age_gate:
+    npm_min_days: 7
+    gem_min_days: 7
+    own_packages:
+      npm: [react-on-rails]
+      gem: [react_on_rails]
+
+repos:
+  - id: fixture-demo
+    github: shakacode/fixture-demo
+    packages:
+      - ecosystem: gem
+        name: react_on_rails
+      - ecosystem: npm
+        name: react-on-rails


### PR DESCRIPTION
## Summary

- establish this repository as the backstage React on Rails Demo Fleet control plane while keeping [reactonrails.com/examples](https://www.reactonrails.com/examples) as the canonical public catalog
- keep each demo repository responsible for its app source, CI, deployment, and review apps; keep release policy and the canonical fleet inventory in `react_on_rails`
- add an experimental cross-repository planner/executor that reads the canonical manifest and applies exact gem/npm versions safely
- add deterministic CI/planning workflows, repository templates, ownership documentation, a release runbook, and copy/paste prompts

## Safety boundary

- the canonical manifest currently yields 0 actionable repositories and 12 pending verification
- manifest-provided commands are explicitly documented as a trusted shell-execution boundary
- freshness mutation remains disabled; the scheduled workflow is planning-only
- hosted CI polling, review-app smoke, tracking-issue updates, merge decisions, and the final release gate remain outside this pilot

## Review fixes

- parse complete multiline Gemfile declarations with `Ripper`, including inline comments and nested hashes
- preserve unique local commits when a previously pushed update branch has been deleted remotely
- validate filtered release targets against the verified fleet and prevent base-only no-op updates in Pro-only repositories, including transitive-only metadata
- return clean schema errors for malformed policy YAML, missing age-gate fields, and non-string repository identifiers
- add least-privilege workflow permissions, memoized plans, and explicit manifest trust-boundary documentation

## Verification

- `ruby -Ilib test/demo_fleet_test.rb` — 81 runs, 373 assertions, 0 failures
- `bundle exec rspec` — 312 examples, 0 failures
- exact hosted RuboCop command — 13 files, no offenses
- changed Markdown/YAML Prettier check — clean
- live canonical and checked-in fixture manifest validation — clean
- fixture release execution dry-run — clean
- final independent autoreview — clean after one independently reproduced release-target gap was fixed and regression-tested
