### PR TITLE
Configure direct merge submission

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,5 +1,7 @@
 ---
 base_branch: main
+merge_submission:
+  mode: direct
 follow_up_prefix: 'Follow-up:'
 review_gate: "all current-head `gh pr checks` entries green, all review threads resolved, mergeable clean; local seam evidence is `.agents/bin/validate` (`bundle exec rake spec`) only, not a replacement for Lefthook pre-push or monorepo lint/format; AGENTS.md permits `gh pr ready` only after its documented local and review-app conditions pass"
 approval_exempt: "this config grants no permanent merge authority; defer merge authority to AGENTS.md or direct user/maintainer instruction. When separately authorized at batch closeout, auto-merge ready low-risk PRs that pass the merge gate; keep high-risk CI/workflow, build-config, dependency or runtime bumps, broad refactors, and release changes maintainer-gated"


### PR DESCRIPTION
## Summary
- explicitly configure the agent-workflow merge submission mode as `direct`
- leave GitHub repository and Merge Queue settings unchanged

## Validation
- Ruby YAML parse and direct-mode assertion
- seam doctor against `shakacode/agent-workflows` main at `845ab026`
- `git diff --check`

Source dependency: shakacode/agent-workflows#407 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the agent workflow configuration to enable direct submission merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->